### PR TITLE
Add LastBits

### DIFF
--- a/CardanoSharp.Wallet.Test/Extensions/ByteArrayExtensionTests.cs
+++ b/CardanoSharp.Wallet.Test/Extensions/ByteArrayExtensionTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CardanoSharp.Wallet.Extensions;
+using Xunit;
+
+namespace CardanoSharp.Wallet.Test.Extensions
+{
+    public class ByteArrayExtensionTests
+    {
+        [Fact]
+        public void LastBits_Returns_LastNBits()
+        {
+            byte b = 0x83;
+            int last = b.LastBits(4);
+            Assert.Equal(0x3, last);
+        }
+    }
+}

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.2.6</Version>
+    <Version>0.2.7</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Extensions/ByteArrayExtension.cs
+++ b/CardanoSharp.Wallet/Extensions/ByteArrayExtension.cs
@@ -188,5 +188,22 @@ namespace CardanoSharp.Wallet.Extensions
 
             return (left, right);
         }
+
+        /// <summary>
+        /// Returns the last n bits of the byte
+        /// </summary>
+        /// <param name="b"></param>
+        /// <param name="n"></param>
+        /// <returns></returns>
+        public static int LastBits(this byte b, int n)
+        {
+            if (n > 8)
+            {
+                throw new InvalidOperationException($"{nameof(n)} must be <= 8");
+            }
+
+            int mask = ~(0xff >> n << n);
+            return b & mask;
+        }
     }
 }


### PR DESCRIPTION
Added a helper to extract last n bits of a byte: 

```cs
var cborByte = 0x83;
var count = cborByte.LastBits(4); // 3
```

bfdotnet uses it to perform some very basic `CBOR` validation before sending Txs. 
