### PR TITLE
Native Asset quantity data type from uint to ulong

### DIFF
--- a/CardanoSharp.Wallet.Test/CardanoSharp.Wallet.Test.csproj
+++ b/CardanoSharp.Wallet.Test/CardanoSharp.Wallet.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CardanoSharp.Wallet.Test/CardanoSharp.Wallet.Test.csproj
+++ b/CardanoSharp.Wallet.Test/CardanoSharp.Wallet.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -409,7 +409,7 @@ namespace CardanoSharp.Wallet.Test
             string txInAddr = getGenesisTransaction().ToStringHex();
 
             string mintAssetName = "token";
-            uint assetAmount = 1;
+            ulong assetAmount = 1;
 
             var mintAsset = TokenBundleBuilder.Create
                 .AddToken(policyId, mintAssetName.ToBytes(), assetAmount);

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Models/Transactions/TransactionBody/NativeAsset.cs
+++ b/CardanoSharp.Wallet/Models/Transactions/TransactionBody/NativeAsset.cs
@@ -8,9 +8,9 @@ namespace CardanoSharp.Wallet.Models.Transactions
     {
         public NativeAsset()
         {
-            Token = new Dictionary<byte[], uint>();
+            Token = new Dictionary<byte[], ulong>();
         }
 
-        public Dictionary<byte[], uint> Token { get; set; }
+        public Dictionary<byte[], ulong> Token { get; set; }
     }
 }

--- a/CardanoSharp.Wallet/TransactionBuilding/NativeAssetBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/NativeAssetBuilder.cs
@@ -12,7 +12,7 @@ namespace CardanoSharp.Wallet.TransactionBuilding
             _model = new NativeAsset();
         }
 
-        public NativeAssetBuilder WithToken(Dictionary<byte[], uint> token)
+        public NativeAssetBuilder WithToken(Dictionary<byte[], ulong> token)
         {
             _model.Token = token;
             return this;

--- a/CardanoSharp.Wallet/TransactionBuilding/TokenBundleBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/TokenBundleBuilder.cs
@@ -8,7 +8,7 @@ namespace CardanoSharp.Wallet.TransactionBuilding
 {
     public interface ITokenBundleBuilder: IABuilder<Dictionary<byte[], NativeAsset>>
     {
-        ITokenBundleBuilder AddToken(byte[] policyId, byte[] asset, uint amount);
+        ITokenBundleBuilder AddToken(byte[] policyId, byte[] asset, ulong amount);
     }
 
     public class TokenBundleBuilder: ABuilder<Dictionary<byte[], NativeAsset>>, ITokenBundleBuilder
@@ -23,7 +23,7 @@ namespace CardanoSharp.Wallet.TransactionBuilding
             get => new TokenBundleBuilder();
         }
 
-        public ITokenBundleBuilder AddToken(byte[] policyId, byte[] asset, uint amount)
+        public ITokenBundleBuilder AddToken(byte[] policyId, byte[] asset, ulong amount)
         {
             var policy = _model.FirstOrDefault(x => x.Key.Equals(policyId));
             if (policy.Key is null)


### PR DESCRIPTION
Changed data type for Native Token quantity from uint to ulong to reflect onchain data type