### PR TITLE
Fix cbor for multiple assets in one transaction output

### DIFF
--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -281,7 +281,7 @@ namespace CardanoSharp.Wallet.Test
         }
 
         [Fact]
-        public void MultiAssetTest()
+        public void OneAssetForEachOutputTest()
         {
             var rootKey = getBase15WordWallet();
 
@@ -317,6 +317,84 @@ namespace CardanoSharp.Wallet.Test
             //assert
             Assert.Equal("a3008282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000001828258390079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65cc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d948201a1581c00000000000000000000000000000000000000000000000000000000a14400010203183c82583900c05e80bdcf267e7fe7bf4a867afe54a65a3605b32aae830ed07f8e1ccc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d948212a1581c00000000000000000000000000000000000000000000000000000000a1440001020318f00201",
                 serialized.ToStringHex());
+        }
+
+
+        [Fact]
+        public void OnePolicyMultiAssetForOneOutputTest()
+        {
+            var rootKey = getBase15WordWallet();
+
+            //get payment keys
+            (var paymentPrv, var paymentPub) = getKeyPairFromPath("m/1852'/1815'/0'/0/0", rootKey);
+
+            //get change keys
+            (var changePrv, var changePub) = getKeyPairFromPath("m/1852'/1815'/0'/1/0", rootKey);
+
+            //get stake keys
+            (var stakePrv, var stakePub) = getKeyPairFromPath("m/1852'/1815'/0'/2/0", rootKey);
+
+            var baseAddr = _addressService.GetAddress(paymentPub, stakePub, NetworkType.Testnet, AddressType.Base);
+            var changeAddr = _addressService.GetAddress(changePub, stakePub, NetworkType.Testnet, AddressType.Base);
+
+            var tokenBundle1 = TokenBundleBuilder.Create
+                .AddToken(getGenesisPolicyId(), "00010203".HexToByteArray(), 60)
+                .AddToken(getGenesisPolicyId(), "00010204".HexToByteArray(), 240);
+
+
+            var transactionBody = TransactionBodyBuilder.Create
+                .AddInput(getGenesisTransaction(), 0)
+                .AddInput(getGenesisTransaction(), 0)
+                .AddOutput(baseAddr, 1, tokenBundle1)
+                .SetFee(1)
+                .Build();
+
+            //act
+            var serialized = transactionBody.Serialize(null);
+
+            //assert
+            var hex = serialized.ToStringHex();
+            Assert.Equal("a3008282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000001818258390079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65cc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d948201a1581c00000000000000000000000000000000000000000000000000000000a24400010203183c440001020418f00201",
+                hex);
+        }
+
+        [Fact]
+        public void MultiplePolicyOneAssetForOneOutputTest()
+        {
+            var rootKey = getBase15WordWallet();
+
+            //get payment keys
+            (var paymentPrv, var paymentPub) = getKeyPairFromPath("m/1852'/1815'/0'/0/0", rootKey);
+
+            //get change keys
+            (var changePrv, var changePub) = getKeyPairFromPath("m/1852'/1815'/0'/1/0", rootKey);
+
+            //get stake keys
+            (var stakePrv, var stakePub) = getKeyPairFromPath("m/1852'/1815'/0'/2/0", rootKey);
+
+            var baseAddr = _addressService.GetAddress(paymentPub, stakePub, NetworkType.Testnet, AddressType.Base);
+            var changeAddr = _addressService.GetAddress(changePub, stakePub, NetworkType.Testnet, AddressType.Base);
+
+            var tokenBundle1 = TokenBundleBuilder.Create
+                .AddToken(getGenesisPolicyId(), "00010203".HexToByteArray(), 60)
+                .AddToken(getTest1PolicyId(), "00010204".HexToByteArray(), 240);
+
+
+            var transactionBody = TransactionBodyBuilder.Create
+                .AddInput(getGenesisTransaction(), 0)
+                .AddInput(getGenesisTransaction(), 0)
+                .AddOutput(baseAddr, 1, tokenBundle1)
+                .SetFee(1)
+                .Build();
+
+            //act
+            var serialized = transactionBody.Serialize(null);
+
+
+            //assert
+            var hex = serialized.ToStringHex();
+            Assert.Equal("a3008282582000000000000000000000000000000000000000000000000000000000000000000082582000000000000000000000000000000000000000000000000000000000000000000001818258390079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65cc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d948201a2581c00000000000000000000000000000000000000000000000000000000a14400010203183c581c01010101010101010101010101010101010101010101010101010101a1440001020418f00201",
+                hex);
         }
 
         [Fact]
@@ -459,6 +537,16 @@ namespace CardanoSharp.Wallet.Test
             for (var i = 0; i < hash.Length; i++)
             {
                 hash[i] = 0x00;
+            }
+            return hash;
+        }
+
+        private byte[] getTest1PolicyId()
+        {
+            var hash = new byte[28];
+            for (var i = 0; i < hash.Length; i++)
+            {
+                hash[i] = 0x01;
             }
             return hash;
         }

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Extensions/ByteArrayExtension.cs
+++ b/CardanoSharp.Wallet/Extensions/ByteArrayExtension.cs
@@ -205,5 +205,10 @@ namespace CardanoSharp.Wallet.Extensions
             int mask = ~(0xff >> n << n);
             return b & mask;
         }
+
+        public static bool SequenceEqual(this byte[] x, byte[] y)
+        {
+            return MemoryExtensions.SequenceEqual<byte>(x, y);
+        }
     }
 }

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionOutputExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionOutputExtensions.cs
@@ -15,11 +15,13 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
                 .Add(transactionOutput.Address);
 
             //determine if the output has any native assets included
-            if (transactionOutput.Value.MultiAsset != null)
+            if (transactionOutput.Value.MultiAsset != null && transactionOutput.Value.MultiAsset.Count != 0)
             {
                 //add any 'coin' aka ADA to the output
                 var cborAssetOutput = CBORObject.NewArray()
                     .Add(transactionOutput.Value.Coin);
+
+                var cborMultiAsset = CBORObject.NewMap();
 
                 //iterate over the multiassets
                 //reminder of this structure
@@ -42,13 +44,12 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
                         assetMap.Add(asset.Key, asset.Value);
                     }
 
-                    //add our PolicyID (policy.Key) and Assets (assetMap)
-                    var multiassetMap = CBORObject.NewMap()
-                        .Add(policy.Key, assetMap);
-
-                    //add our multiasset to our assetOutput
-                    cborAssetOutput.Add(multiassetMap);
+                    //add our PolicyID (policy.Key) and Assets (assetMap) to cborTokenOutput
+                    cborMultiAsset.Add(policy.Key, assetMap);
                 }
+
+                //Add the multi asset to the assets
+                cborAssetOutput.Add(cborMultiAsset);
 
                 //finally add our assetOutput to our transaction output
                 cborTransactionOutput.Add(cborAssetOutput);

--- a/CardanoSharp.Wallet/TransactionBuilding/TokenBundleBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/TokenBundleBuilder.cs
@@ -25,7 +25,7 @@ namespace CardanoSharp.Wallet.TransactionBuilding
 
         public ITokenBundleBuilder AddToken(byte[] policyId, byte[] asset, ulong amount)
         {
-            var policy = _model.FirstOrDefault(x => x.Key.Equals(policyId));
+            var policy = _model.FirstOrDefault(x => x.Key.SequenceEqual(policyId));
             if (policy.Key is null)
             {
                 policy = new KeyValuePair<byte[], NativeAsset>(policyId, new NativeAsset());


### PR DESCRIPTION
This PR tries to fix two issues:

1) Equals for byte arrays does not behave as intended as it only checks reference equals. This causes the same policy id to be added multiple times in the `TokenBundleBuilder` and causes incorrect CBOR.
2) Multi asset outputs were incorrectly converted to CBOR and did not meet the CDDL spec. There was an array, with a map for each policy in the array, but the spec is one map with an entry for each policy. 