### PR TITLE
Remove Bech32 max length validation to support other bech32 encoded entities

### DIFF
--- a/CardanoSharp.Wallet.Test/Bech32Tests.cs
+++ b/CardanoSharp.Wallet.Test/Bech32Tests.cs
@@ -58,6 +58,8 @@ namespace CardanoSharp.Wallet.Test
         [InlineData("addr_test1wrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcl6szpr", "70c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f", 14, "addr_test")]
         [InlineData("stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn", "e0337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251", 28, "stake_test")]
         [InlineData("stake_test17rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcljw6kf", "f0c37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f", 30, "stake_test")]
+        [InlineData("addr_xsk1fzw9r482t0ekua7rcqewg3k8ju5d9run4juuehm2p24jtuzz4dg4wpeulnqhualvtx9lyy7u0h9pdjvmyhxdhzsyy49szs6y8c9zwfp0eqyrqyl290e6dr0q3fvngmsjn4aask9jjr6q34juh25hczw3euust0dw", "489c51d4ea5bf36e77c3c032e446c79728d28f93acb9ccdf6a0aab25f042ab5157073cfcc17e77ec598bf213dc7dca16c99b25ccdb8a04254b0143443e0a27242fc8083013ea2bf3a68de08a59346e129d7bd858b290f408d65cbaa97c09d1cf", 9, "addr_xsk")]
+        [InlineData("policy_sk1krqllaz7ypdfj5s7ak5psunflp5ta80d6fur5wscmwetmwnht4vex2kshz6vurqn366pyxwjzka0jnfpav4hzlmqefqf0dvstxuwt7ckg5gd0", "b0c1fff45e205a99521eeda8187269f868be9dedd2783a3a18dbb2bdba775d59932ad0b8b4ce0c138eb41219d215baf94d21eb2b717f60ca4097b59059b8e5fb", 22, "policy_sk")]
         public void TestValidInputs(string addr, string expectedHex, byte expectedVer, string expectedHrp)
         {
             // Act
@@ -82,7 +84,6 @@ namespace CardanoSharp.Wallet.Test
         [InlineData("1nwldj5", "HRP character out of range")]
         [InlineData("1axkwrx", "HRP character out of range")]
         [InlineData("1eym55h", "HRP character out of range")]
-        //@TODO Fails [InlineData("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx", "overall max length exceeded")]
         [InlineData("pzry9x0s0muk", "no separator")]
         [InlineData("1pzry9x0s0muk", "empty hrp")]
         [InlineData("x1b4n0q5v", "Invalid data format.")]
@@ -124,6 +125,45 @@ namespace CardanoSharp.Wallet.Test
             }
 
             Assert.True(raised);
+        }
+
+        [Theory]
+        [InlineData("stake1u9tdcf6nvpv2j5yywktxyxgrzap042jjxt2p6c4hs87jznq3d0dug")]
+        [InlineData("STAKE1U9TDCF6NVPV2J5YYWKTXYXGRZAP042JJXT2P6C4HS87JZNQ3D0DUG")]
+        [InlineData("stake_test1uptdcf6nvpv2j5yywktxyxgrzap042jjxt2p6c4hs87jznqk890c4")]
+        [InlineData("addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k")]
+        [InlineData("addr_test1wrphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcl6szpr")]
+        [InlineData("addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x")]
+        [InlineData("stake_xsk18rrazt3asvy5fw8x26e90hdcpn0nppvur6rqklr0z0q0wdyftftc3lhxem5nuwzm9w6urmt2fe7g8u4x6gq6a0m5ye7n7j9966d8watk6njtapcx3qgh6ekps6rseymqhpuhelwpv8xqqj25drc08rjqmvsj6kfm")]
+        [InlineData("addr_xsk1fzw9r482t0ekua7rcqewg3k8ju5d9run4juuehm2p24jtuzz4dg4wpeulnqhualvtx9lyy7u0h9pdjvmyhxdhzsyy49szs6y8c9zwfp0eqyrqyl290e6dr0q3fvngmsjn4aask9jjr6q34juh25hczw3euust0dw")]
+        [InlineData("addr_xsk1xqthn0jsmwu0s6666c2rwkykdp8zt2tz0lc4uy3svfjulsmht4vkk088pgadf3hmhh7yaqe2dvrgefmfq44jzs39htkf709c5yked2qngxqj2x8tta6jt6wdq72s8m0lpm90dcdjukcm88g62x254d2uvsvcj6r4")]
+        [InlineData("policy_sk1krqllaz7ypdfj5s7ak5psunflp5ta80d6fur5wscmwetmwnht4vex2kshz6vurqn366pyxwjzka0jnfpav4hzlmqefqf0dvstxuwt7ckg5gd0")]
+        public void ValidBech32IsValidTests(string bech32EncodedValue)
+        {
+            var isValid = Bech32.IsValid(bech32EncodedValue);
+
+            Assert.True(isValid);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData("1nwldj5")]
+        [InlineData("1eym55h")]
+        [InlineData("pzry9x0s0muk")]
+        [InlineData("1pzry9x0s0muk")]
+        [InlineData("x1b4n0q5v")]
+        [InlineData("li1dgmt3")]
+        [InlineData("A1G7SGD8")]
+        [InlineData("addr101234567890abcdefghijklmnopqrstuvwxyz")]
+        [InlineData("stake_test1uptdcf6nvpv2j5yywktxyxgrzap042jjxt2p6c4hs87jznqk890c1")]
+        [InlineData("addr_xsk1fzw9r482t0ekua7rcqewg3k8ju5d9run4juuehm2p24jtuzz4dg4wpeulnqhualvtx9lyy7u0h9pdjvmyhxdhzsyy49szs6y8c9zwfp0eqyrqyl29oe6dr0q3fvngmsjn4aask9jjr6q34juh25hczw3euust0dw")]
+        public void InvalidBech32IsValidTests(string bech32EncodedValue)
+        {
+            var isValid = Bech32.IsValid(bech32EncodedValue);
+
+            Assert.False(isValid);
         }
     }
 }

--- a/CardanoSharp.Wallet.Test/CardanoSharp.Wallet.Test.csproj
+++ b/CardanoSharp.Wallet.Test/CardanoSharp.Wallet.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Encoding/Bech32.cs
+++ b/CardanoSharp.Wallet/Encoding/Bech32.cs
@@ -11,7 +11,6 @@ namespace CardanoSharp.Wallet.Encoding
         /// <summary>
         /// Maximum length of the whole Bech32 string (hrp + separator + data)
         /// </summary>
-        private const int TotalMaxLength = 108; //103 = mainnet length of a delegation address, 108 = testnet length
         private const int CheckSumSize = 6;
         private const int HrpMinLength = 1;
         private const int HrpMaxLength = 83;
@@ -51,7 +50,7 @@ namespace CardanoSharp.Wallet.Encoding
         /// <returns>True if input was a valid bech-32 encoded string (without verifying checksum).</returns>
         public static bool HasValidChars(string bech32EncodedString)
         {
-            if (string.IsNullOrEmpty(bech32EncodedString) || bech32EncodedString.Length > TotalMaxLength)
+            if (string.IsNullOrEmpty(bech32EncodedString))
             {
                 return false;
             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 configuration: Release
+image: Visual Studio 2022
 
 # restore NuGet packages before running MSBuild
 before_build:


### PR DESCRIPTION
The easing of validation for Bech32.IsValid to fix #58 