### PR TITLE
Derive Reward (aka Stake) Address from Base Payment Address in IAddressService

### DIFF
--- a/CardanoSharp.Wallet.Test/AddressTests.cs
+++ b/CardanoSharp.Wallet.Test/AddressTests.cs
@@ -5,6 +5,7 @@ using CardanoSharp.Wallet.Extensions.Models;
 using CardanoSharp.Wallet.Extensions;
 using Xunit;
 using CardanoSharp.Wallet.Models.Keys;
+using System;
 
 namespace CardanoSharp.Wallet.Test
 {
@@ -122,6 +123,33 @@ namespace CardanoSharp.Wallet.Test
         public void HasValidNetworkTest(string addr, bool isValidNetwork)
         {
             Assert.True(new Address(addr).HasValidNetwork() == isValidNetwork);
+        }
+
+        [Theory]
+        [InlineData("addr_test1qqg4gu4vfd3775glq8rjm85x2crmysc920hf5qjj8m7rxef8jemaq77p80ka87tm4vyem0sqnuerpmtw2awtu76dl4jsnk5zw2", "stake_test1uqneva7s00qnhmwnl9a6kzvahcqf7v3sa4h9wh970dxl6egft0emn")]
+        [InlineData("addr_test1qr3ls8ycdxgvlkqzsw2ysk9w2rpdstm208fnpnnsznst0lvalyteh6cvaz0cgqj7q2hprsvtxqp7w6gpf892vch6l5qs6ug90f", "stake_test1uzwlj9umavxw38uyqf0q9ts3cx9nqql8dyq5nj4xvta06qgqp7kfw")]
+        [InlineData("addr1q83ls8ycdxgvlkqzsw2ysk9w2rpdstm208fnpnnsznst0lvalyteh6cvaz0cgqj7q2hprsvtxqp7w6gpf892vch6l5qse249rk", "stake1uxwlj9umavxw38uyqf0q9ts3cx9nqql8dyq5nj4xvta06qg8t55dn")]
+        [InlineData("addr1qyg4gu4vfd3775glq8rjm85x2crmysc920hf5qjj8m7rxef8jemaq77p80ka87tm4vyem0sqnuerpmtw2awtu76dl4jssqfzz4", "stake1uyneva7s00qnhmwnl9a6kzvahcqf7v3sa4h9wh970dxl6egwp9mlw")]
+        [InlineData("addr1q88nszffkdktfcycgy6pvya42vtuemu2rxnfa5pgr5qf5r6kmsn4xczc49gggavkvgvsx96zl249yvk5r43t0q0ay9xq29tngn", "stake1u9tdcf6nvpv2j5yywktxyxgrzap042jjxt2p6c4hs87jznq3d0dug")]
+        public void ExtractRewardAddressTest(string baseAddressBech32, string expectedRewardAddressBech32)
+        {
+            var baseAddress = new Address(baseAddressBech32);
+
+            var rewardAddress = _addressService.ExtractRewardAddress(baseAddress);
+
+            Assert.Equal(expectedRewardAddressBech32, rewardAddress.ToString());
+        }
+
+        [Theory]
+        [InlineData("addr_test1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspjrlsz")]
+        [InlineData("addr1v9u5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0kvk0f")]
+        [InlineData("stake_test1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqp8n5xl")]
+        [InlineData("stake1uyevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqxdekzz")]
+        public void ExtractRewardAddressInvalidTest(string invalidAddress)
+        {
+            var nonBaseAddress = new Address(invalidAddress);
+
+            Assert.Throws<ArgumentException>("basePaymentAddress", () => _addressService.ExtractRewardAddress(nonBaseAddress));
         }
 
         /// <summary>

--- a/CardanoSharp.Wallet.Test/AddressTests.cs
+++ b/CardanoSharp.Wallet.Test/AddressTests.cs
@@ -2,7 +2,6 @@
 using CardanoSharp.Wallet.Enums;
 using CardanoSharp.Wallet.Models.Addresses;
 using CardanoSharp.Wallet.Extensions.Models;
-using CardanoSharp.Wallet.Extensions;
 using Xunit;
 using CardanoSharp.Wallet.Models.Keys;
 using System;

--- a/CardanoSharp.Wallet/AddressService.cs
+++ b/CardanoSharp.Wallet/AddressService.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using CardanoSharp.Wallet.Common;
+using CardanoSharp.Wallet.Encoding;
 using CardanoSharp.Wallet.Enums;
 using CardanoSharp.Wallet.Models.Addresses;
 using CardanoSharp.Wallet.Models.Keys;
@@ -15,6 +16,7 @@ namespace CardanoSharp.Wallet
         Address GetBaseAddress(PublicKey payment, PublicKey stake, NetworkType networkType);
         Address GetRewardAddress(PublicKey stake, NetworkType networkType);
         Address GetEnterpriseAddress(PublicKey payment, NetworkType networkType);
+        Address ExtractRewardAddress(Address basePaymentAddress);
     }
     public class AddressService : IAddressService
     {
@@ -119,6 +121,24 @@ namespace CardanoSharp.Wallet
             return new Address(prefix, addressArray);
         }
 
+        public Address ExtractRewardAddress(Address basePaymentAddress)
+        {
+            if (basePaymentAddress.AddressType != AddressType.Base)
+                throw new ArgumentException($"{nameof(basePaymentAddress)}:{basePaymentAddress} is not a base address", nameof(basePaymentAddress));
+
+            // The stake key digest is the second half of a base address's bytes (pre-bech32)
+            // and same value as the blake2b-224 hash digest of the stake key (blake2b-224=224bits=28bytes)
+            const int stakeKeyDigestByteLength = 28;
+            byte[] rewardAddressBytes = new byte[1 + stakeKeyDigestByteLength];
+            var rewardAddressPrefix = $"{getPrefixHeader(AddressType.Reward)}{getPrefixTail(basePaymentAddress.NetworkType)}";
+            var rewardAddressHeader = getAddressHeader(getNetworkInfo(basePaymentAddress.NetworkType), AddressType.Reward);
+            rewardAddressBytes[0] = rewardAddressHeader;
+            // Extract stake key hash from baseAddressBytes 
+            Buffer.BlockCopy(basePaymentAddress.GetBytes(), 29, rewardAddressBytes, 1, stakeKeyDigestByteLength);
+
+            return new Address(rewardAddressPrefix, rewardAddressBytes);
+        }
+
         private string getPrefixHeader(AddressType addressType) =>
             addressType switch
             {
@@ -152,6 +172,5 @@ namespace CardanoSharp.Wallet
                 AddressType.Reward => (byte)(0b1110_0000 | networkInfo.NetworkId & 0xF),
                 _ => throw new Exception("Unknown address type")
             };
-
     }
 }

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Models/Addresses/Address.cs
+++ b/CardanoSharp.Wallet/Models/Addresses/Address.cs
@@ -66,10 +66,12 @@ namespace CardanoSharp.Wallet.Models.Addresses
         {
             return (_bytes[0] >> 4) switch
             {
-                0x01 => AddressType.Base, //@TODO: derive all AddressTypes
+                0x00 or 0x01 or 0x02 or 0x03 => AddressType.Base,
+                0x04 or 0x05 => AddressType.Ptr, 
                 0x06 => AddressType.Enterprise,
-                //0x07 => AddressType.SmartContract,
-                _ => AddressType.Base,
+                //0x07 => AddressType.Script,
+                0x0e or 0x0f => AddressType.Reward,
+                _ => AddressType.Base, //@TODO: derive all AddressTypes
             };
         }
 


### PR DESCRIPTION
Linked to https://github.com/CardanoSharp/cardanosharp-wallet/issues/63

Wallet users work primarily with base payment addresses but our backend code is more interested in the wallet account's total balance and assets instead of a single payment address.

[BlockFrost](https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1%7Bstake_address%7D/get) and [Koios](https://api.koios.rest/#get-/account_info) expose very useful Acccount-based endpoints accepting a stake address as a request parameter. Lucky for us all the Cardano wallets conveniently share the same underlying stake key and address for all the base payment addresses and we can extract it with a bit of byte data shuffling.

Add a new method to IAddressService and implement it

```c#
Address ExtractRewardAddress(Address baseAddress);
```
Now that we have the reward address we can then query BlockFrost and Koios.

Key criteria

 - Accept testnet and mainnet base payment addresses and extract reward addresses for the same network
 - Input validation to ensure the address is a base payment address
 - Unit test coverage for the above