### PR TITLE
The CDDL For An Alonzo Cardano Transaction Requires an "IsValid" Flag

### DIFF
--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -27,15 +27,13 @@ namespace CardanoSharp.Wallet.Test
         private static string __projectDirectory = Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName;
         private static DirectoryInfo __dat = new DirectoryInfo(__projectDirectory).CreateSubdirectory("dat");
         private static JsonSerializerOptions __jsonSerializerOptions = new JsonSerializerOptions() { WriteIndented = true };
-        private readonly ITestOutputHelper _testOutputHelper;
 
-        public TransactionTests(ITestOutputHelper testOutputHelper)
+        public TransactionTests()
         {
             _keyService = new MnemonicService();
             _addressService = new AddressService();
             _transactionSerializer = new TransactionSerializer();
             DirectoryInfo dat = new DirectoryInfo(__projectDirectory).CreateSubdirectory("dat");
-            _testOutputHelper = testOutputHelper;
         }
 
         [Fact]

--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -15,7 +15,6 @@ using CardanoSharp.Wallet.Extensions.Models.Transactions;
 using CardanoSharp.Wallet.TransactionBuilding;
 using PeterO.Cbor2;
 using System.Linq;
-using Xunit.Abstractions;
 
 namespace CardanoSharp.Wallet.Test
 {
@@ -28,7 +27,7 @@ namespace CardanoSharp.Wallet.Test
         private static DirectoryInfo __dat = new DirectoryInfo(__projectDirectory).CreateSubdirectory("dat");
         private static JsonSerializerOptions __jsonSerializerOptions = new JsonSerializerOptions() { WriteIndented = true };
 
-        public TransactionTests(ITestOutputHelper testOutputHelper)
+        public TransactionTests()
         {
             _keyService = new MnemonicService();
             _addressService = new AddressService();
@@ -102,7 +101,6 @@ namespace CardanoSharp.Wallet.Test
 
             Assert.Equal(expected, actual);
         }
-
 
         [Fact]
         public void DeserializeMultiAssetTransaction()
@@ -188,7 +186,6 @@ namespace CardanoSharp.Wallet.Test
             // Act
             //var actualHex = tx.Serialize().ToStringHex();
             var actual = CBORObject.DecodeFromBytes(tx.Serialize());
-
             var expected = CBORObject.DecodeFromBytes(expectedCBOR);
             Assert.Equal(expected, actual);
 
@@ -396,7 +393,6 @@ namespace CardanoSharp.Wallet.Test
             Assert.Equal("a50081825820000000000000000000000000000000000000000000000000000000000000000000018182583900c05e80bdcf267e7fe7bf4a867afe54a65a3605b32aae830ed07f8e1ccc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d941a0039c702021a000341fe031903e8048282008200581ccc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d9483028200581ccc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d94581ccc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d94",
                 serialized.ToStringHex());
         }
-
 
         [Fact]
         public void OneAssetForEachOutputTest()

--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -28,16 +28,12 @@ namespace CardanoSharp.Wallet.Test
         private static DirectoryInfo __dat = new DirectoryInfo(__projectDirectory).CreateSubdirectory("dat");
         private static JsonSerializerOptions __jsonSerializerOptions = new JsonSerializerOptions() { WriteIndented = true };
 
-
-        private readonly ITestOutputHelper _testOutputHelper;
         public TransactionTests(ITestOutputHelper testOutputHelper)
         {
             _keyService = new MnemonicService();
             _addressService = new AddressService();
             _transactionSerializer = new TransactionSerializer();
             DirectoryInfo dat = new DirectoryInfo(__projectDirectory).CreateSubdirectory("dat");
-
-            _testOutputHelper = testOutputHelper;
         }
 
         [Fact]

--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -15,6 +15,7 @@ using CardanoSharp.Wallet.Extensions.Models.Transactions;
 using CardanoSharp.Wallet.TransactionBuilding;
 using PeterO.Cbor2;
 using System.Linq;
+using Xunit.Abstractions;
 
 namespace CardanoSharp.Wallet.Test
 {
@@ -27,12 +28,16 @@ namespace CardanoSharp.Wallet.Test
         private static DirectoryInfo __dat = new DirectoryInfo(__projectDirectory).CreateSubdirectory("dat");
         private static JsonSerializerOptions __jsonSerializerOptions = new JsonSerializerOptions() { WriteIndented = true };
 
-        public TransactionTests()
+
+        private readonly ITestOutputHelper _testOutputHelper;
+        public TransactionTests(ITestOutputHelper testOutputHelper)
         {
             _keyService = new MnemonicService();
             _addressService = new AddressService();
             _transactionSerializer = new TransactionSerializer();
             DirectoryInfo dat = new DirectoryInfo(__projectDirectory).CreateSubdirectory("dat");
+
+            _testOutputHelper = testOutputHelper;
         }
 
         [Fact]
@@ -93,7 +98,7 @@ namespace CardanoSharp.Wallet.Test
                 .Build();
 
             var expected = expectedTrans.GetCBOR().EncodeToBytes().ToStringHex();
-            
+
             //actual
             var bytes = expected.HexToByteArray();
             var transaction = bytes.DeserializeTransaction();
@@ -101,6 +106,7 @@ namespace CardanoSharp.Wallet.Test
 
             Assert.Equal(expected, actual);
         }
+
 
         [Fact]
         public void DeserializeMultiAssetTransaction()
@@ -170,7 +176,7 @@ namespace CardanoSharp.Wallet.Test
             var utxo = "98035740ab68cad12cb4d8281d10ce1112ef0933dc84920b8937c3e80d78d120".HexToByteArray();
             var payment1Addr = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress();
             var payment2Addr = "addr_test1vqah2xrfp8qjp2tldu8wdq38q8c8tegnduae5zrqff3aeec7g467q".ToAddress();
-            byte[] expectedCBOR = "83a3008182582098035740ab68cad12cb4d8281d10ce1112ef0933dc84920b8937c3e80d78d12000018282581d60d0c43926a989c88d5049e61bdebf2a887aca10fa284b9067373ea28f0082581d603b75186909c120a97f6f0ee6822701f075e5136f3b9a08604a63dce7000200a0f6".HexToByteArray();
+            byte[] expectedCBOR = "84a3008182582098035740ab68cad12cb4d8281d10ce1112ef0933dc84920b8937c3e80d78d12000018282581d60d0c43926a989c88d5049e61bdebf2a887aca10fa284b9067373ea28f0082581d603b75186909c120a97f6f0ee6822701f075e5136f3b9a08604a63dce7000200a0f5f6".HexToByteArray();
 
             // Arrange
 
@@ -186,6 +192,7 @@ namespace CardanoSharp.Wallet.Test
             // Act
             //var actualHex = tx.Serialize().ToStringHex();
             var actual = CBORObject.DecodeFromBytes(tx.Serialize());
+
             var expected = CBORObject.DecodeFromBytes(expectedCBOR);
             Assert.Equal(expected, actual);
 
@@ -355,7 +362,7 @@ namespace CardanoSharp.Wallet.Test
             var serializedTx = transaction.Serialize();
 
             //assert
-            Assert.Equal("83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b70001818258390079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65cc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d94010200030aa10081825820489ef28ea97f719ee7768645fc74b811c271e5d7ef06c2310854db30158e945d5840e6489d8cdc11ac139158b878251819a31f01644310fa4a4b9c72c2319aa8887f4e299054346c2ad08016e4b8f55684ccae8bddcc5e2137af730acbed5642ff09f6",
+            Assert.Equal("84a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b70001818258390079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65cc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d94010200030aa10081825820489ef28ea97f719ee7768645fc74b811c271e5d7ef06c2310854db30158e945d5840e6489d8cdc11ac139158b878251819a31f01644310fa4a4b9c72c2319aa8887f4e299054346c2ad08016e4b8f55684ccae8bddcc5e2137af730acbed5642ff09f5f6",
                 serializedTx.ToStringHex());
         }
 
@@ -394,7 +401,7 @@ namespace CardanoSharp.Wallet.Test
                 serialized.ToStringHex());
         }
 
-        
+
         [Fact]
         public void OneAssetForEachOutputTest()
         {
@@ -572,9 +579,9 @@ namespace CardanoSharp.Wallet.Test
             var fee = transaction.CalculateFee();
 
             //assert
-            Assert.Equal("83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182581d611c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c01021a00016f32030aa10081825820f9aa3fccb7fe539e471188ccc9ee65514c5961c070b06ca185962484a4813bee5840fae5de40c94d759ce13bf9886262159c4f26a289fd192e165995b785259e503f6887bf39dfa23a47cf163784c6eee23f61440e749bc1df3c73975f5231aeda0ff6",
+            Assert.Equal("84a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182581d611c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c01021a00016f32030aa10081825820f9aa3fccb7fe539e471188ccc9ee65514c5961c070b06ca185962484a4813bee5840fae5de40c94d759ce13bf9886262159c4f26a289fd192e165995b785259e503f6887bf39dfa23a47cf163784c6eee23f61440e749bc1df3c73975f5231aeda0ff5f6",
                 serialized.ToStringHex());
-            Assert.Equal((uint)188002, fee);
+            Assert.Equal((uint)189002, fee);
         }
 
         [Fact]
@@ -605,7 +612,7 @@ namespace CardanoSharp.Wallet.Test
             var serialized = transaction.Serialize();
 
             //assert
-            Assert.Equal("83a50081825820000000000000000000000000000000000000000000000000000000000000000000018182583900477367d9134e384a25edd3e23c72735ee6de6490d39c537a247e1b65d9e5a6498b927f664a2c82343aa6a50cdde47de0a2b8c54ecd9c99c21a000f42400200030a0758208dc8a798a1da0e2a6df17e66b10a49b5047133dd4daae2686ef1f73369d3fa16a100818258200f8ad2c7def332bca2f897ef2a1608ee655341227efe7d2284eeb3f94d08d5fa584074a7a181addbda26d7974119ac6e3fe35286fb4a6f7a9db573a5e5836808613097256fa2f0284e255cadc566cef96bde750a3ca5cb79a0726349d3424148e00082a11904d2a1646e616d656e73696d706c65206d65737361676580",
+            Assert.Equal("84a50081825820000000000000000000000000000000000000000000000000000000000000000000018182583900477367d9134e384a25edd3e23c72735ee6de6490d39c537a247e1b65d9e5a6498b927f664a2c82343aa6a50cdde47de0a2b8c54ecd9c99c21a000f42400200030a0758208dc8a798a1da0e2a6df17e66b10a49b5047133dd4daae2686ef1f73369d3fa16a100818258200f8ad2c7def332bca2f897ef2a1608ee655341227efe7d2284eeb3f94d08d5fa584074a7a181addbda26d7974119ac6e3fe35286fb4a6f7a9db573a5e5836808613097256fa2f0284e255cadc566cef96bde750a3ca5cb79a0726349d3424148e000f582a11904d2a1646e616d656e73696d706c65206d65737361676580",
                 serialized.ToStringHex());
         }
 
@@ -668,7 +675,7 @@ namespace CardanoSharp.Wallet.Test
 
             //not the best test but logic was derived from creating this mint
             //  https://explorer.cardano-testnet.iohkdev.io/en/transaction?id=1aff3b12c5b9fb96f0cdcd975b58f6ed273a5680f2ff42a02d82fe0041cf8e3d
-            Assert.Equal("83a6008182582000000000000000000000000000000000000000000000000000000000000000000001818258390079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65cc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d948201a1581c7b45f5a5758a8880b4a6fb0da6d6ad3b11963d217658c7d23ebc62b4a145746f6b656e010200031903e8075820e0850084789cdd38358caaa60f7c0326e9fa3d7bd9acf53c95e348389740da4809a1581c7b45f5a5758a8880b4a6fb0da6d6ad3b11963d217658c7d23ebc62b4a145746f6b656e01a20082825820489ef28ea97f719ee7768645fc74b811c271e5d7ef06c2310854db30158e945d58402cbcd64d35f229665e0de915da5eed37f5a69c937804f3957c534f7fc405dcd3abe9b308e9e743797c749c1aa8ff26c8298bdfea8a9078617039b1b0edab820682582000000000000000000000000000000000000000000000000000000000000000005840e3818414929fbb7cabda04358ba51076bf9e888339efa2fb0783314fcafa01b5d57840ef2e00b6fb3fa7432fcaaaf4c06581c68b8e0d3df3f6dc27b6474c9e0201818201818200581cf9dca21a6c826ec8acb4cf395cbc24351937bfe6560b2683ab8b415f82a1190539a1676d657373616765727368617270206d696e74696e67207465737480",
+            Assert.Equal("84a6008182582000000000000000000000000000000000000000000000000000000000000000000001818258390079467c69a9ac66280174d09d62575ba955748b21dec3b483a9469a65cc339a35f9e0fe039cf510c761d4dd29040c48e9657fdac7e9c01d948201a1581c7b45f5a5758a8880b4a6fb0da6d6ad3b11963d217658c7d23ebc62b4a145746f6b656e010200031903e8075820e0850084789cdd38358caaa60f7c0326e9fa3d7bd9acf53c95e348389740da4809a1581c7b45f5a5758a8880b4a6fb0da6d6ad3b11963d217658c7d23ebc62b4a145746f6b656e01a20082825820489ef28ea97f719ee7768645fc74b811c271e5d7ef06c2310854db30158e945d58402cbcd64d35f229665e0de915da5eed37f5a69c937804f3957c534f7fc405dcd3abe9b308e9e743797c749c1aa8ff26c8298bdfea8a9078617039b1b0edab820682582000000000000000000000000000000000000000000000000000000000000000005840e3818414929fbb7cabda04358ba51076bf9e888339efa2fb0783314fcafa01b5d57840ef2e00b6fb3fa7432fcaaaf4c06581c68b8e0d3df3f6dc27b6474c9e0201818201818200581cf9dca21a6c826ec8acb4cf395cbc24351937bfe6560b2683ab8b415ff582a1190539a1676d657373616765727368617270206d696e74696e67207465737480",
                 signedTxStr);
         }
 

--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -15,7 +15,6 @@ using CardanoSharp.Wallet.Extensions.Models.Transactions;
 using CardanoSharp.Wallet.TransactionBuilding;
 using PeterO.Cbor2;
 using System.Linq;
-using Xunit.Abstractions;
 
 namespace CardanoSharp.Wallet.Test
 {

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.4.2</Version>
+    <Version>2.4.3</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/IsValidExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/IsValidExtensions.cs
@@ -1,0 +1,46 @@
+using CardanoSharp.Wallet.Models.Transactions;
+using PeterO.Cbor2;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace CardanoSharp.Wallet.Extensions.Models.Transactions
+{
+    public static class IsValidExtensions
+    {
+        public static CBORObject GetCBOR(this bool isValid)
+        {
+            return CBORObject.FromObject(isValid);
+        }
+
+        public static bool GetIsValid(this CBORObject isValidCbor)
+        {
+            //validation
+            if (isValidCbor == null)
+            {
+                throw new ArgumentNullException(nameof(isValidCbor));
+            }
+            if (isValidCbor.Type != CBORType.Boolean)
+            {
+                throw new ArgumentException("isValidCbor is not expected type CBORType.Boolean");
+            }
+
+            //get data
+            var isValid = isValidCbor.AsBoolean();
+
+            //return
+            return isValid;
+        }
+
+        public static byte[] Serialize(this bool isValid)
+        {
+            return isValid.GetCBOR().EncodeToBytes();
+        }
+
+        public static bool DeserializeIsValid(this byte[] bytes)
+        {
+            return CBORObject.DecodeFromBytes(bytes).GetIsValid();
+        }
+    }
+}

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
@@ -33,6 +33,9 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
                 cborTransaction.Add(CBORObject.NewMap());
             }
 
+            //add isValid
+            cborTransaction.Add(transaction.IsValid.GetCBOR());
+
             //add metadata
             cborTransaction.Add(transaction.AuxiliaryData != null
                 ? transaction.AuxiliaryData.GetCBOR()

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
@@ -61,11 +61,8 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
             //get data
             var transactionBodyCbor = transactionCbor[0];
             var transactionWitnessSetCbor = transactionCbor[1];
-            CBORObject auxiliaryDataCbor = null;
-            if (transactionCbor.Count > 2)
-            {
-                auxiliaryDataCbor = transactionCbor[2];
-            }
+            var isValid = transactionCbor.Count > 2 ? transactionCbor[2] : null;
+            var auxiliaryDataCbor = transactionCbor.Count > 3 ? transactionCbor[3] : null;
 
             //populate
             var transaction = new Transaction();

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
@@ -61,7 +61,7 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
             //get data
             var transactionBodyCbor = transactionCbor[0];
             var transactionWitnessSetCbor = transactionCbor[1];
-            var isValid = transactionCbor.Count > 2 ? transactionCbor[2] : null;
+            var isValidCbor = transactionCbor.Count > 2 ? transactionCbor[2] : null;
             var auxiliaryDataCbor = transactionCbor.Count > 3 ? transactionCbor[3] : null;
 
             //populate
@@ -70,6 +70,10 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
             if (transactionWitnessSetCbor != null && transactionWitnessSetCbor.Count > 0)
             {
                 transaction.TransactionWitnessSet = transactionWitnessSetCbor.GetTransactionWitnessSet();
+            }
+            if (isValidCbor != null && !isValidCbor.IsNull)
+            {
+                transaction.IsValid = isValidCbor.GetIsValid();
             }
             if (auxiliaryDataCbor != null && !auxiliaryDataCbor.IsNull)
             {

--- a/CardanoSharp.Wallet/Models/Transactions/AuxiliaryData.cs
+++ b/CardanoSharp.Wallet/Models/Transactions/AuxiliaryData.cs
@@ -2,23 +2,23 @@
 
 namespace CardanoSharp.Wallet.Models.Transactions
 {
-	//   auxiliary_data =
-	//{ * transaction_metadatum_label => transaction_metadatum }
-	/// [transaction_metadata: { *transaction_metadatum_label => transaction_metadatum }
-	//, auxiliary_scripts:[ *native_script ]
-	//; other types of metadata...
-	//]
-	//transaction_metadatum_label = uint
+    //   auxiliary_data =
+    //{ * transaction_metadatum_label => transaction_metadatum }
+    /// [transaction_metadata: { *transaction_metadatum_label => transaction_metadatum }
+    //, auxiliary_scripts:[ *native_script ]
+    //; other types of metadata...
+    //]
+    //transaction_metadatum_label = uint
 
-	public partial class AuxiliaryData
+    public partial class AuxiliaryData
     {
-		public AuxiliaryData()
+        public AuxiliaryData()
         {
-			Metadata = new Dictionary<int, object>();
-			List = new List<object>();
+            Metadata = new Dictionary<int, object>();
+            List = new List<object>();
         }
 
         public Dictionary<int, object> Metadata { get; set; }
-		public List<object> List { get; set; }
+        public List<object> List { get; set; }
     }
 }

--- a/CardanoSharp.Wallet/Models/Transactions/Transaction.cs
+++ b/CardanoSharp.Wallet/Models/Transactions/Transaction.cs
@@ -5,16 +5,17 @@ using System.Text;
 namespace CardanoSharp.Wallet.Models.Transactions
 {
     /// <summary>
-    /// Parent class to create transactions. If a child class does not have 
-    /// a comment description, it means that it is a Rust CBOR libary specific 
-    /// type, and type Rust type will match the C# type exactly and it would be 
-    /// repetitive to put the comment. 
+    /// Parent class to create transactions. If a child class does not have
+    /// a comment description, it means that it is a Rust CBOR libary specific
+    /// type, and type Rust type will match the C# type exactly and it would be
+    /// repetitive to put the comment.
     /// Rust libary used for reference -> https://github.com/Emurgo/cardano-serialization-lib/blob/master/rust/src/lib.rs
     /// </summary>
     public class Transaction
     {
         public TransactionBody TransactionBody { get; set; }
         public TransactionWitnessSet TransactionWitnessSet { get; set; }
+        public bool IsValid { get; set; } = true;
         public AuxiliaryData AuxiliaryData { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds an IsValid flag to the Transaction class in line with the Cardano Alonzo CDDL:
https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl

Libraries such as the Rust Cardano Serialization Library implement this like this:
https://github.com/Emurgo/cardano-serialization-lib/blob/3c85d18d80fc6692da5b1d8e0eb5be3f563329ac/rust/src/lib.rs#L104

-----------------------------------------------
Test Updates similar to this commit from SpaceBudz founder alessandrokonrad's in the Cardano Serialization Library
https://github.com/Emurgo/cardano-serialization-lib/commit/18afc1efe28418004d30c0e72b7cab1b1eed671e 