### PR TITLE
Transaction fee calculation fix

### DIFF
--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -870,7 +870,7 @@ namespace CardanoSharp.Wallet.Test
             //assert
             Assert.Equal("84a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182581d611c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c01021a00016f32030aa10081825820f9aa3fccb7fe539e471188ccc9ee65514c5961c070b06ca185962484a4813bee5840fae5de40c94d759ce13bf9886262159c4f26a289fd192e165995b785259e503f6887bf39dfa23a47cf163784c6eee23f61440e749bc1df3c73975f5231aeda0ff5f6",
                 serialized.ToStringHex());
-            Assert.Equal((uint)172013, fee);
+            Assert.Equal((uint)163697, fee);
             Assert.Equal(true, isValid);
         }
 

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.8.1</Version>
+    <Version>2.9.0</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SauceControl.Blake2Fast" Version="2.0.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
@@ -89,7 +89,14 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
             if (!a.HasValue) a = FeeStructure.Coefficient;
             if (!b.HasValue) b = FeeStructure.Constant;
 
-            return ((uint)transaction.Serialize().ToStringHex().Length * a.Value) + b.Value;
+            return ((uint)transaction.Serialize().Length * a.Value) + b.Value;
+        }
+
+        public static uint CalculateAndSetFee(this Transaction transaction, uint? a = null, uint? b = null)
+        {
+            var fee = CalculateFee(transaction, a, b);
+            transaction.TransactionBody.Fee = fee;
+            return fee;
         }
 
         public static byte[] Serialize(this Transaction transaction)

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
@@ -88,7 +88,8 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
         {
             if (!a.HasValue) a = FeeStructure.Coefficient;
             if (!b.HasValue) b = FeeStructure.Constant;
-
+            // Required because zero value => smaller CBOR payload => fee lower than minimum
+            transaction.TransactionBody.Fee = b.Value;
             return ((uint)transaction.Serialize().Length * a.Value) + b.Value;
         }
 


### PR DESCRIPTION
As a fix for https://github.com/CardanoSharp/cardanosharp-wallet/issues/77 

We are calculating the fee based on the length of the hexadecimal string (see `ToStringHex()`) below instead of the byte length.

```c#
public static uint CalculateFee(this Transaction transaction, uint? a = null, uint? b = null)
{
    if (!a.HasValue) a = FeeStructure.Coefficient;
    if (!b.HasValue) b = FeeStructure.Constant;

    return ((uint)transaction.Serialize().ToStringHex().Length * a.Value) + b.Value;
}
```
