### PR TITLE
Another Clear Mocks

### DIFF
--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -13,6 +13,7 @@ using CardanoSharp.Wallet.Extensions.Models.Transactions;
 using CardanoSharp.Wallet.TransactionBuilding;
 using PeterO.Cbor2;
 using System.Linq;
+using CardanoSharp.Wallet.Extensions.Models.Transactions.TransactionWitnesses;
 
 namespace CardanoSharp.Wallet.Test
 {
@@ -932,14 +933,19 @@ namespace CardanoSharp.Wallet.Test
                 .Build();
 
             //act
-            //163257 - 1
-            //
             var fee = transaction.CalculateFee();
+            transaction.TransactionBody.Fee = fee;
             Assert.Equal(expectedFee, (int)fee);
             Assert.NotNull(transaction.TransactionWitnessSet);
-            transactionBody.SetFee(fee);
 
-            witnesses.ClearMocks();
+            //the functionality that is here would automatically be done if you use 
+            //  transaction.CalculateAndSetFee()
+            //  but i wanted to test before and after this piece to ensure "RemoveMocks"
+            //  did remove the IsMock VKeyWitnesses
+            transaction.TransactionWitnessSet.RemoveMocks();
+            Assert.Empty(transaction.TransactionWitnessSet.VKeyWitnesses);
+            
+            //serialize/deserialize transaction to ensure object was built without mocks and has correct fee
             var serializedTx = transaction.Serialize();
             var deserializedTx = serializedTx.DeserializeTransaction();
             Assert.Equal(fee, deserializedTx.TransactionBody.Fee);

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.10.1</Version>
+    <Version>2.10.2</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
@@ -97,6 +97,10 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
         {
             var fee = CalculateFee(transaction, a, b);
             transaction.TransactionBody.Fee = fee;
+
+            if (transaction.TransactionWitnessSet is not null)
+                transaction.TransactionWitnessSet.RemoveMocks();
+            
             return fee;
         }
 

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionWitnesses/TransactionWitnessSetExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionWitnesses/TransactionWitnessSetExtensions.cs
@@ -89,5 +89,18 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions.TransactionWitnesse
         {
             return CBORObject.DecodeFromBytes(bytes).GetTransactionWitnessSet();
         }
+
+        public static void RemoveMocks(this TransactionWitnessSet transactionWitnessSet)
+        {
+            //remove vkey witness mocks
+            if (transactionWitnessSet.VKeyWitnesses is not null)
+            {
+                var mockedWitnesses = transactionWitnessSet.VKeyWitnesses.Where(x => x.IsMock);
+                foreach (var mockedWitness in mockedWitnesses)
+                {
+                    transactionWitnessSet.VKeyWitnesses.Remove(mockedWitness);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
added another way to clear mocks. previously i added a way to clear them via the builder but cscli does not rebuild tx after fee calculation so i needed a way to clear the objects.

To gain more context for PR please review https://github.com/CardanoSharp/cscli/pull/11#issuecomment-1179829601