### PR TITLE
Moved the VKey Witness Mocking

### DIFF
--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.10.2</Version>
+    <Version>2.11.0</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
@@ -93,8 +93,11 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
             return ((uint)transaction.Serialize().Length * a.Value) + b.Value;
         }
 
-        public static uint CalculateAndSetFee(this Transaction transaction, uint? a = null, uint? b = null)
+        public static uint CalculateAndSetFee(this Transaction transaction, uint? a = null, uint? b = null, int mockedVKeyWitnesses = 0)
         {
+            if(mockedVKeyWitnesses > 0)
+                transaction.TransactionWitnessSet.VKeyWitnesses.CreateMocks(mockedVKeyWitnesses);
+            
             var fee = CalculateFee(transaction, a, b);
             transaction.TransactionBody.Fee = fee;
 

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionExtensions.cs
@@ -93,10 +93,18 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
             return ((uint)transaction.Serialize().Length * a.Value) + b.Value;
         }
 
-        public static uint CalculateAndSetFee(this Transaction transaction, uint? a = null, uint? b = null, int mockedVKeyWitnesses = 0)
+        /// <summary>
+        /// This method will create mock witnesses, calculate fee, set the fee, and remove mocks
+        /// </summary>
+        /// <param name="transaction">This is the transaction we are calculating the fee for</param>
+        /// <param name="a">This comes from the protocol parameters. Parameter MinFeeA</param>
+        /// <param name="b">This comes from the protocol parameters. Parameter MinFeeB</param>
+        /// <param name="numberOfVKeyWitnessesToMock">To correctly calculate the fee, we need to have the signatures of all required private keys. You can mock if you cannot currently sign with all. This will ensure the fee is correctly calculated while you gather the signatures</param>
+        /// <returns></returns>
+        public static uint CalculateAndSetFee(this Transaction transaction, uint? a = null, uint? b = null, int numberOfVKeyWitnessesToMock = 0)
         {
-            if(mockedVKeyWitnesses > 0)
-                transaction.TransactionWitnessSet.VKeyWitnesses.CreateMocks(mockedVKeyWitnesses);
+            if(numberOfVKeyWitnessesToMock > 0)
+                transaction.TransactionWitnessSet.VKeyWitnesses.CreateMocks(numberOfVKeyWitnessesToMock);
             
             var fee = CalculateFee(transaction, a, b);
             transaction.TransactionBody.Fee = fee;

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionWitnesses/VKeyWitnessExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionWitnesses/VKeyWitnessExtensions.cs
@@ -3,6 +3,7 @@ using CardanoSharp.Wallet.Models.Transactions;
 using CardanoSharp.Wallet.Utilities;
 using PeterO.Cbor2;
 using System;
+using System.Collections.Generic;
 
 namespace CardanoSharp.Wallet.Extensions.Models.Transactions.TransactionWitnesses
 {
@@ -68,6 +69,29 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions.TransactionWitnesse
         public static VKeyWitness DeserializeVKeyWitness(this byte[] bytes)
         {
             return CBORObject.DecodeFromBytes(bytes).GetVKeyWitness();
+        }
+
+        public static void CreateMocks(this ICollection<VKeyWitness> witnesses, int mocks)
+        {
+            for (var x = 0; x < mocks; x++)
+            {
+                witnesses.Add(new VKeyWitness()
+                {
+                    VKey = new PublicKey(getMockKeyId(32), null),
+                    Signature = getMockKeyId(64),
+                    IsMock = true
+                });
+            }
+        }
+        
+        private static byte[] getMockKeyId(int length)
+        {
+            var hash = new byte[length];
+            for (var i = 0; i < hash.Length; i++)
+            {
+                hash[i] = 0x00;
+            }
+            return hash;
         }
     }
 }

--- a/CardanoSharp.Wallet/TransactionBuilding/TransactionWitnessSetBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/TransactionWitnessSetBuilder.cs
@@ -3,6 +3,7 @@ using CardanoSharp.Wallet.Models.Transactions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using CardanoSharp.Wallet.Extensions.Models.Transactions.TransactionWitnesses;
 
 namespace CardanoSharp.Wallet.TransactionBuilding
 {
@@ -58,16 +59,7 @@ namespace CardanoSharp.Wallet.TransactionBuilding
 
         public ITransactionWitnessSetBuilder MockVKeyWitness(int count = 1)
         {
-            for (var x = 0; x < count; x++)
-            {
-                _model.VKeyWitnesses.Add(new VKeyWitness()
-                {
-                   VKey = new PublicKey(getMockKeyId(32), null),
-                   Signature = getMockKeyId(64),
-                   IsMock = true
-                });
-            }
-
+            _model.VKeyWitnesses.CreateMocks(count);
             return this;
         }
 
@@ -133,16 +125,6 @@ namespace CardanoSharp.Wallet.TransactionBuilding
                 }
             };
             return this;
-        }
-        
-        private byte[] getMockKeyId(int length)
-        {
-            var hash = new byte[length];
-            for (var i = 0; i < hash.Length; i++)
-            {
-                hash[i] = 0x00;
-            }
-            return hash;
         }
     }
 }


### PR DESCRIPTION
I moved the mocking functionality as a `ICollection<VKeyWitness`. This lets us mock with builder and outside of builder. 

Reference
https://github.com/CardanoSharp/cscli/pull/11#discussion_r917519677

