### PR TITLE
Fix output order by using a List instead of HashSet

### DIFF
--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Models/Transactions/TransactionBody/TransactionBody.cs
+++ b/CardanoSharp.Wallet/Models/Transactions/TransactionBody/TransactionBody.cs
@@ -20,13 +20,13 @@ namespace CardanoSharp.Wallet.Models.Transactions
     {
         public TransactionBody()
         {
-            TransactionInputs = new HashSet<TransactionInput>();
-            TransactionOutputs = new HashSet<TransactionOutput>();
+            TransactionInputs = new List<TransactionInput>();
+            TransactionOutputs = new List<TransactionOutput>();
             Mint = new Dictionary<byte[], NativeAsset>();
         }
 
-        public virtual ICollection<TransactionInput> TransactionInputs { get; set; }
-        public virtual ICollection<TransactionOutput> TransactionOutputs { get; set; }
+        public virtual IList<TransactionInput> TransactionInputs { get; set; }
+        public virtual IList<TransactionOutput> TransactionOutputs { get; set; }
         public ulong Fee { get; set; }
         public uint? Ttl { get; set; }
         public Certificate Certificate { get; set; }


### PR DESCRIPTION
As discussed, I've replaced the exposed `ICollection<>` with `IList<>` and it is instantiated with a `List<>`. 
I have done it for both inputs and outputs. I'm not sure if it's necessary for inputs, but let's have it consistent. 

Copy from the discussions for future reference:
So the two things we need in our project, but I think they are very reasonable: 
- being able to depend on the order of outputs, so that it's the same every time we build a tx
- deserialization to 'expose' the index (other than iterating over a HashSet and hoping it matches) 

Just to assess how many problems this could have caused I've done some testing with the C# HashSet implementation.
It seems it will keep the items in the order they were added when iterating over it, as long as nothing has been removed. So likely use cases, where a new tx is built or deserialization have been definitely working. 
