### PR TITLE
Generic Native Asset

### DIFF
--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionBodyExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionBodyExtensions.cs
@@ -161,11 +161,11 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
                 {
                     var byteMintKey = ((string)key.DecodeValueByCborType()).HexToByteArray();
                     var assetCbor = mintCbor[key];
-                    var nativeAsset = new NativeAsset();
+                    var nativeAsset = new NativeAsset<long>();
                     foreach (var assetKey in assetCbor.Keys)
                     {
                         var byteAssetKey = ((string)assetKey.DecodeValueByCborType()).HexToByteArray();
-                        var token = Convert.ToUInt64(assetCbor[assetKey].DecodeValueByCborType());
+                        var token = Convert.ToInt64(assetCbor[assetKey].DecodeValueByCborType());
                         nativeAsset.Token.Add(byteAssetKey, token);
                     }
 

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionOutputExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionOutputExtensions.cs
@@ -102,7 +102,7 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
             {
                 //multi asset
                 transactionOutput.Value = new TransactionOutputValue();
-                transactionOutput.Value.MultiAsset = new Dictionary<byte[], NativeAsset>();
+                transactionOutput.Value.MultiAsset = new Dictionary<byte[], NativeAsset<ulong>>();
 
                 var coinCbor = transactionOutputCbor[1][0];
                 transactionOutput.Value.Coin = Convert.ToUInt64(coinCbor.DecodeValueByCborType());
@@ -110,14 +110,14 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
                 var multiAssetCbor = transactionOutputCbor[1][1];
                 foreach (var policyKeyCbor in multiAssetCbor.Keys)
                 {
-                    var nativeAsset = new NativeAsset();
+                    var nativeAsset = new NativeAsset<ulong>();
 
                     var assetMapCbor = multiAssetCbor[policyKeyCbor];
                     var policyKeyBytes = ((string)policyKeyCbor.DecodeValueByCborType()).HexToByteArray();
 
                     foreach (var assetKeyCbor in assetMapCbor.Keys)
                     {
-                        var assetToken = Convert.ToUInt64(assetMapCbor[assetKeyCbor].DecodeValueByCborType());
+                        var assetToken = Convert.ToUInt32(assetMapCbor[assetKeyCbor].DecodeValueByCborType());
                         var assetKeyBytes = ((string)assetKeyCbor.DecodeValueByCborType()).HexToByteArray();
 
                         nativeAsset.Token.Add(assetKeyBytes, assetToken);

--- a/CardanoSharp.Wallet/Models/Transactions/TransactionBody/NativeAsset.cs
+++ b/CardanoSharp.Wallet/Models/Transactions/TransactionBody/NativeAsset.cs
@@ -4,13 +4,13 @@ using System.Text;
 
 namespace CardanoSharp.Wallet.Models.Transactions
 {
-    public partial class NativeAsset
+    public partial class NativeAsset<T>
     {
         public NativeAsset()
         {
-            Token = new Dictionary<byte[], ulong>();
+            Token = new Dictionary<byte[], T>();
         }
 
-        public Dictionary<byte[], ulong> Token { get; set; }
+        public Dictionary<byte[], T> Token { get; set; }
     }
 }

--- a/CardanoSharp.Wallet/Models/Transactions/TransactionBody/TransactionBody.cs
+++ b/CardanoSharp.Wallet/Models/Transactions/TransactionBody/TransactionBody.cs
@@ -23,7 +23,7 @@ public partial class TransactionBody
         {
             TransactionInputs = new HashSet<TransactionInput>();
             TransactionOutputs = new HashSet<TransactionOutput>();
-            Mint = new Dictionary<byte[], NativeAsset>();
+            Mint = new Dictionary<byte[], NativeAsset<long>>();
         }
 
         public virtual ICollection<TransactionInput> TransactionInputs { get; set; }
@@ -35,6 +35,6 @@ public partial class TransactionBody
         public Update Update { get; set; }
         public string MetadataHash { get; set; }
         public uint? TransactionStartInterval { get; set; }
-        public Dictionary<byte[], NativeAsset> Mint { get; set; }
+        public Dictionary<byte[], NativeAsset<long>> Mint { get; set; }
     }
 }

--- a/CardanoSharp.Wallet/Models/Transactions/TransactionBody/TransactionOutputValue.cs
+++ b/CardanoSharp.Wallet/Models/Transactions/TransactionBody/TransactionOutputValue.cs
@@ -11,6 +11,6 @@ namespace CardanoSharp.Wallet.Models.Transactions
         /// BPlusTree<byte[], NativeAsset>
         /// byte[] = PolicyID
         /// </summary>
-        public Dictionary<byte[], NativeAsset> MultiAsset { get; set; }
+        public Dictionary<byte[], NativeAsset<ulong>> MultiAsset { get; set; }
     }
 }

--- a/CardanoSharp.Wallet/TransactionBuilding/NativeAssetBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/NativeAssetBuilder.cs
@@ -5,24 +5,24 @@ using System.Text;
 
 namespace CardanoSharp.Wallet.TransactionBuilding
 {
-    public interface INativeAssetBuilder: IABuilder<NativeAsset>
+    public interface INativeAssetBuilder: IABuilder<NativeAsset<ulong>>
     {
         INativeAssetBuilder WithToken(Dictionary<byte[], ulong> token);
     }
 
-    public class NativeAssetBuilder: ABuilder<NativeAsset>, INativeAssetBuilder
+    public class NativeAssetBuilder: ABuilder<NativeAsset<ulong>>, INativeAssetBuilder
     {
         public NativeAssetBuilder()
         {
-            _model = new NativeAsset();
+            _model = new NativeAsset<ulong>();
         }
 
-        private NativeAssetBuilder(NativeAsset model)
+        private NativeAssetBuilder(NativeAsset<ulong> model)
         {
             _model = model;
         }
 
-        public static INativeAssetBuilder GetBuilder(NativeAsset model)
+        public static INativeAssetBuilder GetBuilder(NativeAsset<ulong> model)
         {
             if (model == null)
             {

--- a/CardanoSharp.Wallet/TransactionBuilding/TokenBundleBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/TokenBundleBuilder.cs
@@ -6,24 +6,24 @@ using System.Text;
 
 namespace CardanoSharp.Wallet.TransactionBuilding
 {
-    public interface ITokenBundleBuilder: IABuilder<Dictionary<byte[], NativeAsset>>
+    public interface ITokenBundleBuilder: IABuilder<Dictionary<byte[], NativeAsset<ulong>>>
     {
         ITokenBundleBuilder AddToken(byte[] policyId, byte[] asset, ulong amount);
     }
 
-    public class TokenBundleBuilder: ABuilder<Dictionary<byte[], NativeAsset>>, ITokenBundleBuilder
+    public class TokenBundleBuilder: ABuilder<Dictionary<byte[], NativeAsset<ulong>>>, ITokenBundleBuilder
     {
         private TokenBundleBuilder()
         {
-            _model = new Dictionary<byte[], NativeAsset>();
+            _model = new Dictionary<byte[], NativeAsset<ulong>>();
         }
 
-        private TokenBundleBuilder(Dictionary<byte[], NativeAsset> model)
+        private TokenBundleBuilder(Dictionary<byte[], NativeAsset<ulong>> model)
         {
             _model = model;
         }
 
-        public static ITokenBundleBuilder GetBuilder(Dictionary<byte[], NativeAsset> model)
+        public static ITokenBundleBuilder GetBuilder(Dictionary<byte[], NativeAsset<ulong>> model)
         {
             if (model == null)
             {
@@ -42,7 +42,7 @@ namespace CardanoSharp.Wallet.TransactionBuilding
             var policy = _model.FirstOrDefault(x => x.Key.SequenceEqual(policyId));
             if (policy.Key is null)
             {
-                policy = new KeyValuePair<byte[], NativeAsset>(policyId, new NativeAsset());
+                policy = new KeyValuePair<byte[], NativeAsset<ulong>>(policyId, new NativeAsset<ulong>());
                 _model.Add(policy.Key, policy.Value);
             }
 

--- a/CardanoSharp.Wallet/TransactionBuilding/TokenBurnBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/TokenBurnBuilder.cs
@@ -1,0 +1,53 @@
+using CardanoSharp.Wallet.Models.Transactions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CardanoSharp.Wallet.TransactionBuilding
+{
+    public interface ITokenBurnBuilder: IABuilder<Dictionary<byte[], NativeAsset<long>>>
+    {
+        ITokenBurnBuilder AddToken(byte[] policyId, byte[] asset, long amount);
+    }
+
+    public class TokenBurnBuilder: ABuilder<Dictionary<byte[], NativeAsset<long>>>, ITokenBurnBuilder
+    {
+        private TokenBurnBuilder()
+        {
+            _model = new Dictionary<byte[], NativeAsset<long>>();
+        }
+
+        private TokenBurnBuilder(Dictionary<byte[], NativeAsset<long>> model)
+        {
+            _model = model;
+        }
+
+        public static ITokenBurnBuilder GetBuilder(Dictionary<byte[], NativeAsset<long>> model)
+        {
+            if (model == null)
+            {
+                return new TokenBurnBuilder();
+            }
+            return new TokenBurnBuilder(model);
+        }
+
+        public static ITokenBurnBuilder Create
+        {
+            get => new TokenBurnBuilder();
+        }
+
+        public ITokenBurnBuilder AddToken(byte[] policyId, byte[] asset, long amount)
+        {
+            var policy = _model.FirstOrDefault(x => x.Key.SequenceEqual(policyId));
+            if (policy.Key is null)
+            {
+                policy = new KeyValuePair<byte[], NativeAsset<long>>(policyId, new NativeAsset<long>());
+                _model.Add(policy.Key, policy.Value);
+            }
+
+            policy.Value.Token.Add(asset, amount);
+            return this;
+        }
+    }
+}

--- a/CardanoSharp.Wallet/TransactionBuilding/TransactionOutputValueBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/TransactionOutputValueBuilder.cs
@@ -9,7 +9,7 @@ namespace CardanoSharp.Wallet.TransactionBuilding
     {
         ITransactionOutputValueBuilder WithCoin(uint coin);
 
-        ITransactionOutputValueBuilder WithMultiAsset(Dictionary<byte[], NativeAsset> multiAsset);
+        ITransactionOutputValueBuilder WithMultiAsset(Dictionary<byte[], NativeAsset<ulong>> multiAsset);
     }
 
     public class TransactionOutputValueBuilder: ABuilder<TransactionOutputValue>, ITransactionOutputValueBuilder
@@ -39,7 +39,7 @@ namespace CardanoSharp.Wallet.TransactionBuilding
             return this;
         }
 
-        public ITransactionOutputValueBuilder WithMultiAsset(Dictionary<byte[], NativeAsset> multiAsset)
+        public ITransactionOutputValueBuilder WithMultiAsset(Dictionary<byte[], NativeAsset<ulong>> multiAsset)
         {
             _model.MultiAsset = multiAsset;
             return this;


### PR DESCRIPTION
Currently, Native Assets are not generic. 

According to the Cardano CDDL: https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl

The "Mint" property requires an int64 instead of a uint64 to handle token burning. This PR adds this functionality