### PR TITLE
feat: add support for preview and preprod environments

### DIFF
--- a/CardanoSharp.Wallet/AddressService.cs
+++ b/CardanoSharp.Wallet/AddressService.cs
@@ -230,6 +230,8 @@ namespace CardanoSharp.Wallet
             networkType switch
             {
                 NetworkType.Testnet => "_test",
+                NetworkType.Preview => "_test",
+                NetworkType.Preprod => "_test",
                 NetworkType.Mainnet => "",
                 _ => throw new Exception("Unknown address type")
             };
@@ -238,6 +240,8 @@ namespace CardanoSharp.Wallet
             type switch
             {
                 NetworkType.Testnet => new NetworkInfo(0b0000, 1097911063),
+                NetworkType.Preview => new NetworkInfo(0b0000, 2),
+                NetworkType.Preprod => new NetworkInfo(0b0000, 1),
                 NetworkType.Mainnet => new NetworkInfo(0b0001, 764824073),
                 _ => throw new Exception("Unknown network type")
             };

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.15.0</Version>
+    <Version>2.16.0</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Common/NetworkInfo.cs
+++ b/CardanoSharp.Wallet/Common/NetworkInfo.cs
@@ -3,12 +3,12 @@
     public class NetworkInfo
     {
         public int NetworkId { get; set; }
-        public int ProtocolMagic { get; set; }
+        public int NetworkMagic { get; set; }
 
-        public NetworkInfo(int networkId, int protocolMagic)
+        public NetworkInfo(int networkId, int networkMagic)
         {
             NetworkId = networkId;
-            ProtocolMagic = protocolMagic;
+            NetworkMagic = networkMagic;
         }
     }
 }

--- a/CardanoSharp.Wallet/Enums/NetworkType.cs
+++ b/CardanoSharp.Wallet/Enums/NetworkType.cs
@@ -4,6 +4,8 @@
     {
         Unknown,
         Testnet,
+        Preview,
+        Preprod,
         Mainnet
     }
 }


### PR DESCRIPTION
- Renamed `NetworkInfo.ProtocolMagic` to `NetworkInfo.NetworkMagic` (it was called protocol magic in the Byron era and was renamed to network magic in the Shelley era)
- Added `Preview` and `Preprod` `NetowrkTypes`
- Initialize `NetworkInfo` for new environments with expected values (info taken from the `shelley-genesis.json` files here: https://book.world.dev.cardano.org/environments.html)

TODO:
- [ ] Add some tests
- [ ] Clarify if the `NetworkInfo.NetworkId` is correct. I haven't found it in the config files..