### PR TITLE
Overhauling Coin Selection To Enable Multichange Selection At 5kb Output Edge Cases

### DIFF
--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/CIP2TestInitialize.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/CIP2TestInitialize.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using CardanoSharp.Wallet.CIPs.CIP2;
-using CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies;
 using CardanoSharp.Wallet.Enums;
 using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Extensions.Models;
 using CardanoSharp.Wallet.Models;
 using CardanoSharp.Wallet.Models.Transactions;
 using CardanoSharp.Wallet.TransactionBuilding;
-using Xunit;
 
 namespace CardanoSharp.Wallet.Test.CIPs;
 
@@ -25,10 +22,6 @@ public partial class CIP2Tests
     private TransactionOutput output_10_ada_100_minted_assets;
     private TransactionOutput output_10_ada_2_minted_assets;
     private TransactionOutput output_10_ada_200_minted_assets;
-    private TransactionOutput output_10_ada_1_burned_assets;
-    private TransactionOutput output_10_ada_100_burned_assets;
-    private TransactionOutput output_10_ada_2_burned_assets;
-    private TransactionOutput output_10_ada_200_burned_assets;
     private TransactionOutput output_10_ada_1_already_minted_assets;
     private TransactionOutput output_10_ada_100_already_minted_assets;
     private TransactionOutput output_10_ada_2_already_minted_assets;
@@ -84,7 +77,16 @@ public partial class CIP2Tests
     private ITokenBundleBuilder burn_1_token_100_quantity;
     private ITokenBundleBuilder burn_2_token_1_quantity;
     private ITokenBundleBuilder burn_2_token_100_quantity;
-    private ITokenBundleBuilder burn_3_token_1_quantity;
+    private ITokenBundleBuilder burn_3_token_1_quantity;    
+        
+    private string mint_policy_1 = "4a4c17cc89b90f7239ce83f41e4f47005859870178f4e6815b1cd318";
+    private string mint_policy_1_asset_1 = "ADABlob1";
+    private string mint_policy_2 = "4a4c17cc89b90f7239ce83f41e4f47005859870178f4e6815b1cd317";
+    private string mint_policy_2_asset_1 = "SpaceBlob1";
+    private string mint_policy_3 = "d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc";
+    private string mint_policy_3_asset_1 = "ADABlobs1";
+    private string mint_policy_4 = "d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cb";
+    private string mint_policy_4_asset_1 = "SpaceBlobs1";
 
     public CIP2Tests()
     {
@@ -321,15 +323,6 @@ public partial class CIP2Tests
                 Assets = new List<Asset>() { asset_50_tokens }
             }
         };
-        
-        var mint_policy_1 = "4a4c17cc89b90f7239ce83f41e4f47005859870178f4e6815b1cd318";
-        var mint_policy_1_asset_1 = "ADABlob1";
-        var mint_policy_2 = "4a4c17cc89b90f7239ce83f41e4f47005859870178f4e6815b1cd317";
-        var mint_policy_2_asset_1 = "SpaceBlob1";
-        var mint_policy_3 = "d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cc";
-        var mint_policy_3_asset_1 = "ADABlobs1";
-        var mint_policy_4 = "d5e6bf0500378d4f0da4e8dde6becec7621cd8cbf5cbb9b87013d4cb";
-        var mint_policy_4_asset_1 = "SpaceBlobs1";
 
         mint_1_token_1_quantity = (ITokenBundleBuilder)TokenBundleBuilder.Create;
         mint_1_token_1_quantity.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
@@ -497,50 +490,6 @@ public partial class CIP2Tests
             {
                 Coin = 10 * lovelace,
                 MultiAsset = mint_2_token_100_quantity.Build()
-            },
-            OutputPurpose = OutputPurpose.Mint,
-        };
-
-        output_10_ada_1_burned_assets = new TransactionOutput()
-        {
-            Address = address.ToAddress().GetBytes(),
-            Value = new TransactionOutputValue()
-            {
-                Coin = 10 * lovelace,
-                MultiAsset = burn_1_token_1_quantity.Build()
-            },
-            OutputPurpose = OutputPurpose.Mint,
-        };
-
-        output_10_ada_100_burned_assets = new TransactionOutput()
-        {
-            Address = address.ToAddress().GetBytes(),
-            Value = new TransactionOutputValue()
-            {
-                Coin = 10 * lovelace,
-                MultiAsset = burn_1_token_100_quantity.Build()
-            },
-            OutputPurpose = OutputPurpose.Mint,
-        };
-
-        output_10_ada_2_burned_assets = new TransactionOutput()
-        {
-            Address = address.ToAddress().GetBytes(),
-            Value = new TransactionOutputValue()
-            {
-                Coin = 10 * lovelace,
-                MultiAsset = burn_2_token_1_quantity.Build()
-            },
-            OutputPurpose = OutputPurpose.Mint,
-        };
-
-        output_10_ada_200_burned_assets = new TransactionOutput()
-        {
-            Address = address.ToAddress().GetBytes(),
-            Value = new TransactionOutputValue()
-            {
-                Coin = 10 * lovelace,
-                MultiAsset = burn_2_token_100_quantity.Build()
             },
             OutputPurpose = OutputPurpose.Mint,
         };

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/CIP2TestInitialize.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/CIP2TestInitialize.cs
@@ -15,6 +15,7 @@ namespace CardanoSharp.Wallet.Test.CIPs;
 
 public partial class CIP2Tests
 {
+    private ulong adaToLovelace = 1000000;
     private string address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu";
     private TransactionOutput output_1_ada_no_assets;
     private TransactionOutput output_10_ada_no_assets;

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/CIP2TestInitialize.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/CIP2TestInitialize.cs
@@ -509,7 +509,7 @@ public partial class CIP2Tests
                 Coin = 10 * lovelace,
                 MultiAsset = burn_1_token_1_quantity.Build()
             },
-            OutputPurpose = OutputPurpose.Burn,
+            OutputPurpose = OutputPurpose.Mint,
         };
 
         output_10_ada_100_burned_assets = new TransactionOutput()
@@ -520,7 +520,7 @@ public partial class CIP2Tests
                 Coin = 10 * lovelace,
                 MultiAsset = burn_1_token_100_quantity.Build()
             },
-            OutputPurpose = OutputPurpose.Burn,
+            OutputPurpose = OutputPurpose.Mint,
         };
 
         output_10_ada_2_burned_assets = new TransactionOutput()
@@ -531,7 +531,7 @@ public partial class CIP2Tests
                 Coin = 10 * lovelace,
                 MultiAsset = burn_2_token_1_quantity.Build()
             },
-            OutputPurpose = OutputPurpose.Burn,
+            OutputPurpose = OutputPurpose.Mint,
         };
 
         output_10_ada_200_burned_assets = new TransactionOutput()
@@ -542,7 +542,7 @@ public partial class CIP2Tests
                 Coin = 10 * lovelace,
                 MultiAsset = burn_2_token_100_quantity.Build()
             },
-            OutputPurpose = OutputPurpose.Burn,
+            OutputPurpose = OutputPurpose.Mint,
         };
 
         output_10_ada_1_already_minted_assets = new TransactionOutput()

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/CIP2TestInitialize.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/CIP2TestInitialize.cs
@@ -15,6 +15,7 @@ namespace CardanoSharp.Wallet.Test.CIPs;
 
 public partial class CIP2Tests
 {
+    private string address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu";
     private TransactionOutput output_1_ada_no_assets;
     private TransactionOutput output_10_ada_no_assets;
     private TransactionOutput output_100_ada_no_assets;
@@ -183,7 +184,7 @@ public partial class CIP2Tests
 
         output_1_ada_no_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 1 * lovelace
@@ -192,7 +193,7 @@ public partial class CIP2Tests
         
         output_10_ada_no_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace
@@ -201,7 +202,7 @@ public partial class CIP2Tests
         
         output_100_ada_no_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 100 * lovelace
@@ -210,7 +211,7 @@ public partial class CIP2Tests
         
         output_10_ada_50_tokens = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -457,7 +458,7 @@ public partial class CIP2Tests
         
         output_10_ada_1_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -468,7 +469,7 @@ public partial class CIP2Tests
 
         output_10_ada_100_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -479,7 +480,7 @@ public partial class CIP2Tests
 
         output_10_ada_2_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -490,7 +491,7 @@ public partial class CIP2Tests
 
         output_10_ada_200_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -501,7 +502,7 @@ public partial class CIP2Tests
 
         output_10_ada_1_burned_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -512,7 +513,7 @@ public partial class CIP2Tests
 
         output_10_ada_100_burned_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -523,7 +524,7 @@ public partial class CIP2Tests
 
         output_10_ada_2_burned_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -534,7 +535,7 @@ public partial class CIP2Tests
 
         output_10_ada_200_burned_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -545,7 +546,7 @@ public partial class CIP2Tests
 
         output_10_ada_1_already_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -556,7 +557,7 @@ public partial class CIP2Tests
 
         output_10_ada_100_already_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -567,7 +568,7 @@ public partial class CIP2Tests
 
         output_10_ada_2_already_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -578,7 +579,7 @@ public partial class CIP2Tests
 
         output_10_ada_200_already_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -589,7 +590,7 @@ public partial class CIP2Tests
 
         output_10_ada_50_tokens_1_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,
@@ -616,7 +617,7 @@ public partial class CIP2Tests
 
         output_10_ada_50_tokens_100_minted_assets = new TransactionOutput()
         {
-            Address = "addr_test1vrgvgwfx4xyu3r2sf8nphh4l92y84jsslg5yhyr8xul29rczf3alu".ToAddress().GetBytes(),
+            Address = address.ToAddress().GetBytes(),
             Value = new TransactionOutputValue()
             {
                 Coin = 10 * lovelace,

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBasicTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBasicTests.cs
@@ -73,7 +73,7 @@ public partial class CIP2Tests
         try
         {
             //act
-            var response = coinSelection.GetCoinSelection(outputs, utxos, address, 5);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, limit: 5);
         }
         catch (Exception e)
         {
@@ -97,7 +97,7 @@ public partial class CIP2Tests
         try
         {
             //act
-            var response = coinSelection.GetCoinSelection(outputs, utxos, address, 5);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, limit: 5);
         }
         catch (Exception e)
         {

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBasicTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBasicTests.cs
@@ -12,7 +12,7 @@ namespace CardanoSharp.Wallet.Test.CIPs;
 
 public partial class CIP2Tests
 {
-     [Fact]
+    [Fact]
     public void LargestFirst_Simple_Test()
     {
         //arrange
@@ -190,4 +190,136 @@ public partial class CIP2Tests
                     outputs.Sum(x => (long)x.Value.Coin)));
     }
 
+    [Fact]
+    public void LargestFirst_MultiChange_Simple_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets, 
+            utxo_10_ada_no_assets, 
+            utxo_30_ada_no_assets, 
+            utxo_50_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_30_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_30_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_SingleUtxo_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_WithTokens_Test()
+    {
+        //arrange 
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_40_tokens, 
+            utxo_10_ada_10_tokens, 
+            utxo_10_ada_30_tokens, 
+            utxo_10_ada_50_tokens
+        };
+        
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        
+        //assert
+        //assert that selected utxo ada value is greater than the requested outputs' ada value
+        Assert.True(response.SelectedUtxos.Sum(x => (long)x.Balance.Lovelaces) > outputs.Sum(x => (long)x.Value.Coin));
+        Assert.Equal(response.ChangeOutputs.Count, 2);
+
+        //assert that selected utxo assets equal output + change asset values
+        Assert.Equal(
+            response.SelectedUtxos.Sum(x => 
+                x.Balance.Assets.Where(y => 
+                    y.PolicyId.Equals(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                        ?.Sum(z => (long)z.Quantity) ?? 0), 
+            (response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Sum(y => 
+                    y.Value.Token.Sum(z => (long)z.Value)) ?? 0)
+                    +
+                    outputs.Sum(x =>
+                        x.Value.MultiAsset?.Sum(y => 
+                            y.Value.Token.Sum(z => (long)z.Value)) ?? 0))
+            );
+        
+        //assert that selected utxo ada value equal output + change utxo ada value
+        Assert.Equal(response.SelectedUtxos.Sum(x => (long) x.Balance.Lovelaces), 
+            (response.ChangeOutputs.Sum(x => (long)x.Value.Coin) 
+                    +
+                    outputs.Sum(x => (long)x.Value.Coin)));
+    }
+    
+    [Fact]
+    public void LargestFirst_MultiChange_WithTokensAndAda_Test()
+    {
+        //arrange 
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens, output_100_ada_no_assets };
+        var utxos = new List<Utxo>();
+        for (var x = 0; x < 20; x++)
+        {
+            utxos.Add(utxo_10_ada_20_tokens);
+        }
+        
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        
+        //assert
+        //assert that selected utxo ada value is greater than the requested outputs' ada value
+        Assert.True(response.SelectedUtxos.Sum(x => (long)x.Balance.Lovelaces) > outputs.Sum(x => (long)x.Value.Coin));
+        Assert.Equal(response.ChangeOutputs.Count, 2);
+
+        //assert that selected utxo assets equal output + change asset values
+        Assert.Equal(
+            response.SelectedUtxos.Sum(x => 
+                x.Balance.Assets.Where(y => 
+                    y.PolicyId.Equals(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                        ?.Sum(z => (long)z.Quantity) ?? 0), 
+            (response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Sum(y => 
+                    y.Value.Token.Sum(z => (long)z.Value)) ?? 0)
+                    +
+                    outputs.Sum(x =>
+                        x.Value.MultiAsset?.Sum(y => 
+                            y.Value.Token.Sum(z => (long)z.Value)) ?? 0))
+            );
+        
+        //assert that selected utxo ada value equal output + change utxo ada value
+        Assert.Equal(response.SelectedUtxos.Sum(x => (long) x.Balance.Lovelaces), 
+            (response.ChangeOutputs.Sum(x => (long)x.Value.Coin) 
+                    +
+                    outputs.Sum(x => (long)x.Value.Coin)));
+    }
 }

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBasicTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBasicTests.cs
@@ -191,10 +191,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_Simple_Test()
+    public void LargestFirst_BasicChange_Simple_Test()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -218,10 +218,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_SingleUtxo_Test()
+    public void LargestFirst_BasicChange_SingleUtxo_Test()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -238,10 +238,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_WithTokens_Test()
+    public void LargestFirst_BasicChange_WithTokens_Test()
     {
         //arrange 
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens };
         var utxos = new List<Utxo>()
         {
@@ -257,7 +257,7 @@ public partial class CIP2Tests
         //assert
         //assert that selected utxo ada value is greater than the requested outputs' ada value
         Assert.True(response.SelectedUtxos.Sum(x => (long)x.Balance.Lovelaces) > outputs.Sum(x => (long)x.Value.Coin));
-        Assert.Equal(response.ChangeOutputs.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
 
         //assert that selected utxo assets equal output + change asset values
         Assert.Equal(
@@ -282,10 +282,10 @@ public partial class CIP2Tests
     }
     
     [Fact]
-    public void LargestFirst_MultiChange_WithTokensAndAda_Test()
+    public void LargestFirst_BasicChange_WithTokensAndAda_Test()
     {
         //arrange 
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens, output_100_ada_no_assets };
         var utxos = new List<Utxo>();
         for (var x = 0; x < 20; x++)
@@ -299,7 +299,7 @@ public partial class CIP2Tests
         //assert
         //assert that selected utxo ada value is greater than the requested outputs' ada value
         Assert.True(response.SelectedUtxos.Sum(x => (long)x.Balance.Lovelaces) > outputs.Sum(x => (long)x.Value.Coin));
-        Assert.Equal(response.ChangeOutputs.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
 
         //assert that selected utxo assets equal output + change asset values
         Assert.Equal(

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBasicTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBasicTests.cs
@@ -27,7 +27,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -50,7 +50,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -73,7 +73,7 @@ public partial class CIP2Tests
         try
         {
             //act
-            var response = coinSelection.GetCoinSelection(outputs, utxos, 5);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, 5);
         }
         catch (Exception e)
         {
@@ -97,7 +97,7 @@ public partial class CIP2Tests
         try
         {
             //act
-            var response = coinSelection.GetCoinSelection(outputs, utxos, 5);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, 5);
         }
         catch (Exception e)
         {
@@ -121,7 +121,7 @@ public partial class CIP2Tests
         };
         
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
         
         //assert
         //assert that selected utxo ada value is greater than the requested outputs' ada value
@@ -162,7 +162,7 @@ public partial class CIP2Tests
         }
         
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
         
         //assert
         //assert that selected utxo ada value is greater than the requested outputs' ada value

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBurnTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBurnTests.cs
@@ -381,4 +381,374 @@ public partial class CIP2Tests
         Assert.Equal(outputsSumAsset4, 50);
         Assert.Equal(changeOutputSumAsset4, 30);
     }
+
+    [Fact]
+    public void LargestFirst_MultiChange_SingleOutput_Burn_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_1_burned_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+
+        var selectedUTXOsSum = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+                x.Balance.Assets.Where(y => 
+                    y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                        ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var changeOutputSum = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        var outputsSum = outputs.Sum(x =>
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(selectedUTXOsSum + outputsSum + changeOutputSum, 0);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiOutput_Burn_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_1_ada_no_assets, output_10_ada_1_burned_assets, output_1_ada_no_assets, output_1_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_30_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+
+        var selectedUTXOsSum = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+                x.Balance.Assets.Where(y => 
+                    y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                        ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var changeOutputSum = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        var outputsSum = outputs.Sum(x =>
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(selectedUTXOsSum + outputsSum + changeOutputSum, 0);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_SingleOutput_MultiBurn_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_burned_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_1_owned_mint_asset_two
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        Assert.Equal(selectedUTXOsSumAsset1 + outputsSumAsset1 + changeOutputSumAsset1, 0);
+        Assert.Equal(selectedUTXOsSumAsset2 + outputsSumAsset2 + changeOutputSumAsset2, 0);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiOutput_MultiBurn_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_burned_assets, output_10_ada_2_burned_assets, output_10_ada_1_burned_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_1_owned_mint_asset_two,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_1_owned_mint_asset_two,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[4].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 5);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        Assert.Equal(selectedUTXOsSumAsset1 + outputsSumAsset1 + changeOutputSumAsset1, 0);
+        Assert.Equal(selectedUTXOsSumAsset2 + outputsSumAsset2 + changeOutputSumAsset2, 0);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiUtxo_MultiOutput_MultiBurn_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_burned_assets, output_10_ada_50_tokens, output_100_ada_no_assets, output_10_ada_1_already_minted_assets, output_10_ada_2_burned_assets, output_10_ada_1_burned_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_50_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset_two,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_70_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset_two,
+            utxo_10_ada_40_tokens,
+            utxo_10_ada_20_tokens,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_60_ada_no_assets,
+            utxo_10_ada_10_tokens,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[4].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[5].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[5].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[6].TxHash, utxo_10_ada_40_tokens.TxHash);
+        Assert.Equal(response.Inputs[6].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[7].TxHash, utxo_10_ada_20_tokens.TxHash);
+        Assert.Equal(response.Inputs[7].TransactionId, utxo_10_ada_20_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[8].TxHash, utxo_70_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[8].TransactionId, utxo_70_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[9].TxHash, utxo_60_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[9].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 10);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        Assert.Equal(selectedUTXOsSumAsset1 + outputsSumAsset1 + changeOutputSumAsset1, 2);
+        Assert.Equal(selectedUTXOsSumAsset2 + outputsSumAsset2 + changeOutputSumAsset2, 0);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiUtxo_MultiOutput_MultiMint_MultiBurn_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_burned_assets, output_10_ada_50_tokens, output_100_ada_no_assets, output_10_ada_1_already_minted_assets, output_10_ada_100_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_minted_assets, output_10_ada_2_burned_assets, output_10_ada_1_burned_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_50_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset_two,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_70_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset_two,
+            utxo_10_ada_40_tokens,
+            utxo_10_ada_20_tokens,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_60_ada_no_assets,
+            utxo_10_ada_10_tokens,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_30_tokens,
+            utxo_10_ada_40_tokens,
+            utxo_80_ada_no_assets,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[4].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[5].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[5].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[6].TxHash, utxo_10_ada_40_tokens.TxHash);
+        Assert.Equal(response.Inputs[6].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[7].TxHash, utxo_10_ada_40_tokens.TxHash);
+        Assert.Equal(response.Inputs[7].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[8].TxHash, utxo_80_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[8].TransactionId, utxo_80_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[9].TxHash, utxo_70_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[9].TransactionId, utxo_70_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 10);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var selectedUTXOsSumAsset3 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_100_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+        var selectedUTXOsSumAsset4 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var outputsSumAsset3 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_100_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_100_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var outputsSumAsset4 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var changeOutputSumAsset3 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_100_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_100_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        var changeOutputSumAsset4 = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        Assert.Equal(selectedUTXOsSumAsset1, 4);
+        Assert.Equal(outputsSumAsset1, 0);
+        Assert.Equal(changeOutputSumAsset1, 0);
+
+        Assert.Equal(selectedUTXOsSumAsset2, 2);
+        Assert.Equal(outputsSumAsset2, -2);
+        Assert.Equal(changeOutputSumAsset2, 0);
+
+        Assert.Equal(selectedUTXOsSumAsset3, 0);
+        Assert.Equal(outputsSumAsset3, 100);
+        Assert.Equal(changeOutputSumAsset3, 0);
+
+        Assert.Equal(selectedUTXOsSumAsset4, 80);
+        Assert.Equal(outputsSumAsset4, 50);
+        Assert.Equal(changeOutputSumAsset4, 30);
+    }
 }

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBurnTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBurnTests.cs
@@ -390,9 +390,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_SingleOutput_Burn_Test()
+    public void LargestFirst_BasicChange_SingleOutput_Burn_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -428,9 +428,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiOutput_Burn_Test()
+    public void LargestFirst_BasicChange_MultiOutput_Burn_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_1_ada_no_assets, output_10_ada_no_assets, output_1_ada_no_assets, output_1_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -467,9 +467,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_SingleOutput_MultiBurn_Test()
+    public void LargestFirst_BasicChange_SingleOutput_MultiBurn_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -519,9 +519,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiOutput_MultiBurn_Test()
+    public void LargestFirst_BasicChange_MultiOutput_MultiBurn_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -580,9 +580,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiUtxo_MultiOutput_MultiBurn_Test()
+    public void LargestFirst_BasicChange_MultiUtxo_MultiOutput_MultiBurn_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_50_tokens, output_10_ada_no_assets, output_10_ada_1_already_minted_assets, output_10_ada_no_assets, output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -629,7 +629,7 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[9].TxHash, utxo_60_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[9].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos.Count, 10);
-        Assert.Equal(response.ChangeOutputs.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
 
         var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
             x.Balance.Assets.Where(y => 
@@ -658,9 +658,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiUtxo_MultiOutput_MultiMint_MultiBurn_Test()
+    public void LargestFirst_BasicChange_MultiUtxo_MultiOutput_MultiMint_MultiBurn_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_50_tokens, output_10_ada_no_assets, output_10_ada_1_already_minted_assets, output_10_ada_100_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_minted_assets, output_10_ada_no_assets, output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -711,7 +711,7 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[9].TxHash, utxo_70_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[9].TransactionId, utxo_70_ada_no_assets.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos.Count, 10);
-        Assert.Equal(response.ChangeOutputs.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
 
         var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
             x.Balance.Assets.Where(y => 

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBurnTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstBurnTests.cs
@@ -24,7 +24,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
@@ -63,7 +63,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
@@ -101,7 +101,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
@@ -152,7 +152,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
@@ -216,7 +216,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
@@ -293,7 +293,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstFeeTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstFeeTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CardanoSharp.Wallet.CIPs.CIP2;
+using CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies;
+using CardanoSharp.Wallet.Extensions;
+using CardanoSharp.Wallet.Models;
+using CardanoSharp.Wallet.Models.Transactions;
+using Xunit;
+
+namespace CardanoSharp.Wallet.Test.CIPs;
+
+public partial class CIP2Tests
+{
+    [Fact]
+    public void LargestFirst_Simple_Fee_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new SingleTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_50_ada_no_assets, 
+            utxo_50_ada_no_assets,
+            utxo_10_ada_no_assets,
+            utxo_20_ada_no_assets,
+        };
+
+        //act
+        ulong feeBuffer = 21 * adaToLovelace;
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: feeBuffer);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_50_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_20_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_20_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_no_assets.TxHash.HexToByteArray());
+        
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+        long finalChangeOutputChange = (long)response.ChangeOutputs.Last().Value.Coin;
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.True((ulong)finalChangeOutputChange >= feeBuffer);
+    }
+
+    [Fact]
+    public void LargestFirst_Simple_Fee_Fail_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new SingleTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_50_ada_no_assets, 
+            utxo_50_ada_no_assets,
+            utxo_10_ada_no_assets,
+        };
+
+        //assert
+        try
+        {
+            //act
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: 11 * adaToLovelace);
+        }
+        catch (Exception e)
+        {
+            //assert
+            Assert.Equal("UTxOs have insufficient balance", e.Message);
+        }
+    }
+    
+    [Fact]
+    public void LargestFirst_MultiChange_Fee_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_10_tokens, 
+            utxo_10_ada_1_owned_mint_asset, 
+            utxo_10_ada_1_owned_mint_asset_two, 
+            utxo_10_ada_100_owned_mint_asset,
+        };
+
+        //act
+        ulong feeBuffer = 3 * adaToLovelace;
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: feeBuffer);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_10_tokens.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_10_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_100_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_100_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 4);
+        Assert.Equal(response.ChangeOutputs.Count, 5);
+
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+        long finalChangeOutputChange = (long)response.ChangeOutputs.Last().Value.Coin;
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.True((ulong)finalChangeOutputChange >= feeBuffer);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_Fee_Test_2()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_10_tokens, 
+            utxo_10_ada_1_owned_mint_asset, 
+            utxo_10_ada_1_owned_mint_asset_two, 
+            utxo_10_ada_100_owned_mint_asset,
+            utxo_10_ada_100_owned_mint_asset_two,
+        };
+
+        //act
+        ulong feeBuffer = 11 * adaToLovelace;
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: 11 * adaToLovelace);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_10_tokens.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_10_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_100_owned_mint_asset.TxHash);
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_100_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_10_ada_100_owned_mint_asset_two.TxHash);
+        Assert.Equal(response.Inputs[4].TransactionId, utxo_10_ada_100_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 5);
+        Assert.Equal(response.ChangeOutputs.Count, 5);
+        Assert.Equal(response.ChangeOutputs.First().Value.MultiAsset.Count, 2);
+
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+        long finalChangeOutputChange = (long)response.ChangeOutputs.Last().Value.Coin;
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.True((ulong)finalChangeOutputChange >= feeBuffer);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_Fee_Fail_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_50_ada_no_assets, 
+            utxo_50_ada_no_assets,
+            utxo_10_ada_no_assets,
+        };
+
+        //assert
+        try
+        {
+            //act
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: 11 * adaToLovelace);
+        }
+        catch (Exception e)
+        {
+            //assert
+            Assert.Equal("UTxOs have insufficient balance", e.Message);
+        }
+    }
+}

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstFeeTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstFeeTests.cs
@@ -78,10 +78,10 @@ public partial class CIP2Tests
     }
     
     [Fact]
-    public void LargestFirst_MultiChange_Fee_Test()
+    public void LargestFirst_BasicChange_Fee_Test()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -105,7 +105,7 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_100_owned_mint_asset.TxHash);
         Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_100_owned_mint_asset.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos.Count, 4);
-        Assert.Equal(response.ChangeOutputs.Count, 5);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
 
         long totalSelected = 0;
         response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
@@ -119,10 +119,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_Fee_Test_2()
+    public void LargestFirst_BasicChange_Fee_Test_2()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -149,8 +149,8 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_10_ada_100_owned_mint_asset_two.TxHash);
         Assert.Equal(response.Inputs[4].TransactionId, utxo_10_ada_100_owned_mint_asset_two.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos.Count, 5);
-        Assert.Equal(response.ChangeOutputs.Count, 5);
-        Assert.Equal(response.ChangeOutputs.First().Value.MultiAsset.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+        Assert.Equal(response.ChangeOutputs.First().Value.MultiAsset.Count, 5);
 
         long totalSelected = 0;
         response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
@@ -164,10 +164,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_Fee_Fail_Test()
+    public void LargestFirst_BasicChange_Fee_Fail_Test()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
         var utxos = new List<Utxo>()
         {

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstMintTests.cs
@@ -23,7 +23,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -42,7 +42,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -61,7 +61,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -84,7 +84,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -108,7 +108,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_50_tokens.TxHash);
@@ -154,7 +154,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -174,7 +174,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -193,7 +193,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -218,7 +218,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_40_tokens.TxHash);
@@ -274,7 +274,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -297,7 +297,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);        
@@ -318,7 +318,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -342,7 +342,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -371,7 +371,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -400,7 +400,7 @@ public partial class CIP2Tests
         try
         {
             //act            
-            var response = coinSelection.GetCoinSelection(outputs, utxos);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address);
         }
         catch (Exception e)
         {
@@ -425,7 +425,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_40_tokens.TxHash);        
@@ -461,7 +461,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstMintTests.cs
@@ -535,9 +535,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_SingleUTXO_SingleOutput_Mint_Test()
+    public void LargestFirst_BasicChange_SingleUTXO_SingleOutput_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -558,9 +558,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiUTXO_SingleOutput_Mint_Test()
+    public void LargestFirst_BasicChange_MultiUTXO_SingleOutput_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -582,9 +582,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_SingleUTXO_MultiOutput_Mint_Test()
+    public void LargestFirst_BasicChange_SingleUTXO_MultiOutput_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -605,9 +605,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiUTXO_MultiOutput_Mint_Test()
+    public void LargestFirst_BasicChange_MultiUTXO_MultiOutput_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -636,9 +636,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_WithTokens_Mint_Test()
+    public void LargestFirst_BasicChange_WithTokens_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -659,7 +659,7 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_30_tokens.TxHash);
         Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_30_tokens.TxHash.HexToByteArray()); 
         Assert.Equal(response.SelectedUtxos.Count, 3);
-        Assert.Equal(response.ChangeOutputs.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
 
         var selectedUTXOsSum = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
                 x.Balance.Assets.Where(y => 
@@ -688,9 +688,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_SingleUTXO_SingleOutput_MultiMint_Test()
+    public void LargestFirst_BasicChange_SingleUTXO_SingleOutput_MultiMint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -712,9 +712,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiUTXO_SingleOutput_MultiMint_Test()
+    public void LargestFirst_BasicChange_MultiUTXO_SingleOutput_MultiMint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -737,9 +737,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_SingleUTXO_MultiOutput_MultiMint_Test()
+    public void LargestFirst_BasicChange_SingleUTXO_MultiOutput_MultiMint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -761,9 +761,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiUTXO_MultiOutput_MultiMint_Test()
+    public void LargestFirst_BasicChange_MultiUTXO_MultiOutput_MultiMint_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_50_tokens, output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -793,7 +793,7 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_60_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[3].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos.Count, 4);
-        Assert.Equal(response.ChangeOutputs.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
 
         var selectedUTXOsSum = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
                 x.Balance.Assets.Where(y => 
@@ -826,9 +826,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MintAndOwned_Test()
+    public void LargestFirst_BasicChange_MintAndOwned_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -852,9 +852,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MintAndOwned_Test_2()
+    public void LargestFirst_BasicChange_MintAndOwned_Test_2()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -877,9 +877,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MintAndOwned_Test_3()
+    public void LargestFirst_BasicChange_MintAndOwned_Test_3()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -904,9 +904,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MintAndOwned_Test_4()
+    public void LargestFirst_BasicChange_MintAndOwned_Test_4()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_2_already_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -934,9 +934,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MintAndOwned_Test_5()
+    public void LargestFirst_BasicChange_MintAndOwned_Test_5()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_2_already_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -965,13 +965,13 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_40_tokens.TxHash);        
         Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos.Count, 4);
-        Assert.Equal(response.ChangeOutputs.Count, 3);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiOption_Test()
+    public void LargestFirst_BasicChange_MultiOption_Test()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_100_ada_no_assets, output_10_ada_50_tokens };
         var utxos = new List<Utxo>()
         {
@@ -1004,13 +1004,13 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[5].TxHash, utxo_10_ada_100_owned_mint_asset.TxHash);        
         Assert.Equal(response.Inputs[5].TransactionId, utxo_10_ada_100_owned_mint_asset.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos.Count, 6);
-        Assert.Equal(response.ChangeOutputs.Count, 4);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
-    public void LargestFirst_MultiChange_MultiOption_Test_2()
+    public void LargestFirst_BasicChange_MultiOption_Test_2()
     {
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets, output_100_ada_no_assets, output_10_ada_50_tokens };
         var utxos = new List<Utxo>()
         {
@@ -1042,6 +1042,6 @@ public partial class CIP2Tests
         Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_60_ada_no_assets.TxHash);        
         Assert.Equal(response.Inputs[4].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos.Count, 5);
-        Assert.Equal(response.ChangeOutputs.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 }

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstMintTests.cs
@@ -6,6 +6,7 @@ using CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies;
 using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Models;
 using CardanoSharp.Wallet.Models.Transactions;
+using CardanoSharp.Wallet.TransactionBuilding;
 using Xunit;
 
 namespace CardanoSharp.Wallet.Test.CIPs;
@@ -23,7 +24,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -44,7 +45,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -64,7 +65,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -88,7 +89,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -114,7 +115,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_50_tokens.TxHash);
@@ -162,8 +163,12 @@ public partial class CIP2Tests
             utxo_40_ada_no_assets,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -183,8 +188,12 @@ public partial class CIP2Tests
             utxo_50_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -203,8 +212,12 @@ public partial class CIP2Tests
             utxo_40_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -229,8 +242,12 @@ public partial class CIP2Tests
             utxo_10_ada_10_tokens,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_40_tokens.TxHash);
@@ -285,8 +302,11 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -309,7 +329,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);        
@@ -329,8 +349,12 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -353,8 +377,12 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset_two,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -382,8 +410,12 @@ public partial class CIP2Tests
             utxo_10_ada_30_tokens
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -409,10 +441,14 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         try
         {
             //act            
-            var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
         }
         catch (Exception e)
         {
@@ -436,8 +472,12 @@ public partial class CIP2Tests
             utxo_10_ada_20_tokens,            
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_40_tokens.TxHash);        
@@ -472,8 +512,12 @@ public partial class CIP2Tests
             utxo_90_ada_no_assets,           
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -500,8 +544,11 @@ public partial class CIP2Tests
             utxo_40_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -521,8 +568,11 @@ public partial class CIP2Tests
             utxo_50_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -541,8 +591,11 @@ public partial class CIP2Tests
             utxo_40_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -565,8 +618,11 @@ public partial class CIP2Tests
             utxo_30_ada_no_assets,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -591,8 +647,11 @@ public partial class CIP2Tests
             utxo_50_ada_no_assets,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_50_tokens.TxHash);
@@ -638,8 +697,12 @@ public partial class CIP2Tests
             utxo_40_ada_no_assets,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -659,8 +722,12 @@ public partial class CIP2Tests
             utxo_50_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
@@ -679,8 +746,12 @@ public partial class CIP2Tests
             utxo_40_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -705,8 +776,12 @@ public partial class CIP2Tests
             utxo_10_ada_10_tokens,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_40_tokens.TxHash);
@@ -761,8 +836,11 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -784,8 +862,12 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);        
@@ -805,8 +887,12 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -829,8 +915,12 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset_two,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -858,8 +948,12 @@ public partial class CIP2Tests
             utxo_10_ada_30_tokens
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
@@ -889,8 +983,12 @@ public partial class CIP2Tests
             utxo_10_ada_20_tokens,            
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_40_tokens.TxHash);        
@@ -925,8 +1023,12 @@ public partial class CIP2Tests
             utxo_90_ada_no_assets,           
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/LargestFirstTests/LargestFirstMintTests.cs
@@ -28,8 +28,10 @@ public partial class CIP2Tests
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
+
     [Fact]
     public void LargestFirst_MultiUTXO_SingleOutput_Mint_Test()
     {
@@ -47,7 +49,8 @@ public partial class CIP2Tests
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[0].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -66,7 +69,8 @@ public partial class CIP2Tests
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -93,6 +97,8 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_30_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[2].TransactionId, utxo_30_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 3);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -115,7 +121,10 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_50_tokens.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_30_tokens.TxHash);
         Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_30_tokens.TxHash.HexToByteArray()); 
-        Asset.Equals(response.SelectedUtxos.Count, 3);
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_50_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 3);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
 
         var selectedUTXOsSum = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
                 x.Balance.Assets.Where(y => 
@@ -159,7 +168,8 @@ public partial class CIP2Tests
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
-        Asset.Equals(response.ChangeOutputs.Count, 1);
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -179,7 +189,8 @@ public partial class CIP2Tests
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[0].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -198,7 +209,8 @@ public partial class CIP2Tests
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -229,8 +241,8 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[2].TransactionId, utxo_90_ada_no_assets.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_60_ada_no_assets.TxHash);
         Assert.Equal(response.Inputs[3].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
-        Asset.Equals(response.SelectedUtxos.Count, 4);
-        Assert.True(response.ChangeOutputs.Count() == 2);
+        Assert.Equal(response.SelectedUtxos.Count, 4);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
 
         var selectedUTXOsSum = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
                 x.Balance.Assets.Where(y => 
@@ -281,8 +293,8 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_40_ada_no_assets.TxHash);        
         Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.SelectedUtxos.Count() == 2);
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -302,8 +314,8 @@ public partial class CIP2Tests
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);        
         Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.SelectedUtxos.Count() == 1);
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -325,8 +337,8 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_40_ada_no_assets.TxHash);        
         Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.SelectedUtxos.Count() == 2);
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -351,8 +363,8 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_40_ada_no_assets.TxHash);        
         Assert.Equal(response.Inputs[2].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.SelectedUtxos.Count() == 3);
-        Assert.True(response.ChangeOutputs.Count() == 1);
+        Assert.Equal(response.SelectedUtxos.Count, 3);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
     }
 
     [Fact]
@@ -382,8 +394,8 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[2].TransactionId, utxo_10_ada_100_owned_mint_asset.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_40_tokens.TxHash);        
         Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
-        Assert.True(response.SelectedUtxos.Count() == 4);
-        Assert.True(response.ChangeOutputs.Count() == 2);
+        Assert.Equal(response.SelectedUtxos.Count, 4);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
     }
 
     [Fact]
@@ -440,8 +452,8 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[4].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[5].TxHash, utxo_10_ada_100_owned_mint_asset.TxHash);        
         Assert.Equal(response.Inputs[5].TransactionId, utxo_10_ada_100_owned_mint_asset.TxHash.HexToByteArray());
-        Assert.True(response.SelectedUtxos.Count() == 6);
-        Assert.True(response.ChangeOutputs.Count() == 2);
+        Assert.Equal(response.SelectedUtxos.Count, 6);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
     }
 
     [Fact]
@@ -474,7 +486,460 @@ public partial class CIP2Tests
         Assert.Equal(response.Inputs[3].TransactionId, utxo_90_ada_no_assets.TxHash.HexToByteArray());
         Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_60_ada_no_assets.TxHash);        
         Assert.Equal(response.Inputs[4].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
-        Assert.True(response.SelectedUtxos.Count() == 5);
-        Assert.True(response.ChangeOutputs.Count() == 2);
+        Assert.Equal(response.SelectedUtxos.Count, 5);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_SingleUTXO_SingleOutput_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiUTXO_SingleOutput_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_50_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_SingleUTXO_MultiOutput_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiUTXO_MultiOutput_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_no_assets,
+            utxo_50_ada_no_assets,
+            utxo_20_ada_no_assets,
+            utxo_30_ada_no_assets,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_30_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_30_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 3);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_WithTokens_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_30_tokens, 
+            utxo_10_ada_50_tokens,
+            utxo_50_ada_no_assets,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_50_tokens.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_50_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_30_tokens.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_30_tokens.TxHash.HexToByteArray()); 
+        Assert.Equal(response.SelectedUtxos.Count, 3);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
+
+        var selectedUTXOsSum = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+                x.Balance.Assets.Where(y => 
+                    y.PolicyId.Equals(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                        ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var changeOutputSum = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        var outputsSum = outputs.Sum(x =>
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+    
+        Assert.Equal(selectedUTXOsSum, changeOutputSum + outputsSum);
+
+        var mint = mint_1_token_1_quantity.Build();
+        var mintQuantity = mint.Sum(x => x.Value.Token.Sum(z => (long)z.Value));
+        Asset.Equals(mintQuantity, 1);
+
+        // //assert that selected utxo ada value equal output + change utxo ada value
+        Assert.Equal(response.SelectedUtxos.Sum(x => (long) x.Balance.Lovelaces), 
+            (response.ChangeOutputs.Sum(x => (long)x.Value.Coin) 
+                    +
+                    outputs.Sum(x => (long)x.Value.Coin)));
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_SingleUTXO_SingleOutput_MultiMint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiUTXO_SingleOutput_MultiMint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_50_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_50_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_50_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_SingleUTXO_MultiOutput_MultiMint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiUTXO_MultiOutput_MultiMint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_50_tokens, output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_50_ada_no_assets,
+            utxo_10_ada_40_tokens,
+            utxo_10_ada_30_tokens,
+            utxo_60_ada_no_assets,
+            utxo_90_ada_no_assets,
+            utxo_10_ada_10_tokens,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_40_tokens.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_30_tokens.TxHash);
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_30_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_90_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_90_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_60_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 4);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
+
+        var selectedUTXOsSum = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+                x.Balance.Assets.Where(y => 
+                    y.PolicyId.Equals(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                        ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var changeOutputSum = response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+        
+        var outputsSum = outputs.Sum(x =>
+                x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                    y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+    
+        Assert.Equal(selectedUTXOsSum, changeOutputSum + outputsSum);
+
+        var mintOne = mint_2_token_1_quantity.Build();
+        var mintQuantityOne = mintOne.Sum(x => x.Value.Token.Sum(z => (long)z.Value));
+        Asset.Equals(mintQuantityOne, 2);
+
+        var mintTwo = mint_2_token_1_quantity.Build();
+        var mintQuantityTwo = mintTwo.Sum(x => x.Value.Token.Sum(z => (long)z.Value));
+        Asset.Equals(mintQuantityTwo, 2);
+
+        // //assert that selected utxo ada value equal output + change utxo ada value
+        Assert.Equal(response.SelectedUtxos.Sum(x => (long) x.Balance.Lovelaces), 
+            (response.ChangeOutputs.Sum(x => (long)x.Value.Coin) 
+                    +
+                    outputs.Sum(x => (long)x.Value.Coin)));
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MintAndOwned_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_40_ada_no_assets.TxHash);        
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MintAndOwned_Test_2()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);        
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 1);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MintAndOwned_Test_3()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_40_ada_no_assets.TxHash);        
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MintAndOwned_Test_4()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_2_already_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_1_owned_mint_asset_two,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());        
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);        
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_40_ada_no_assets.TxHash);        
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 3);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MintAndOwned_Test_5()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_2_already_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_100_owned_mint_asset,
+            utxo_10_ada_40_tokens,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_1_owned_mint_asset_two,
+            utxo_10_ada_50_tokens,
+            utxo_10_ada_30_tokens
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());        
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_1_owned_mint_asset_two.TxHash);        
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_1_owned_mint_asset_two.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_10_ada_100_owned_mint_asset.TxHash);        
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_10_ada_100_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_10_ada_40_tokens.TxHash);        
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 4);
+        Assert.Equal(response.ChangeOutputs.Count, 3);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiOption_Test()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_100_ada_no_assets, output_10_ada_50_tokens };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_100_owned_mint_asset,
+            utxo_10_ada_40_tokens,
+            utxo_60_ada_no_assets,            
+            utxo_10_ada_20_tokens,            
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_40_tokens.TxHash);        
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_20_tokens.TxHash);        
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_20_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_60_ada_no_assets.TxHash);        
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_40_ada_no_assets.TxHash);        
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
+        Assert.Equal(response.Inputs[4].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[5].TxHash, utxo_10_ada_100_owned_mint_asset.TxHash);        
+        Assert.Equal(response.Inputs[5].TransactionId, utxo_10_ada_100_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 6);
+        Assert.Equal(response.ChangeOutputs.Count, 4);
+    }
+
+    [Fact]
+    public void LargestFirst_MultiChange_MultiOption_Test_2()
+    {
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets, output_100_ada_no_assets, output_10_ada_50_tokens };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_100_owned_mint_asset,
+            utxo_10_ada_40_tokens,
+            utxo_60_ada_no_assets,            
+            utxo_10_ada_20_tokens, 
+            utxo_90_ada_no_assets,           
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_10_ada_1_owned_mint_asset.TxHash);        
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_10_ada_1_owned_mint_asset.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[1].TxHash, utxo_10_ada_40_tokens.TxHash);        
+        Assert.Equal(response.Inputs[1].TransactionId, utxo_10_ada_40_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[2].TxHash, utxo_10_ada_20_tokens.TxHash);        
+        Assert.Equal(response.Inputs[2].TransactionId, utxo_10_ada_20_tokens.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[3].TxHash, utxo_90_ada_no_assets.TxHash);        
+        Assert.Equal(response.Inputs[3].TransactionId, utxo_90_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos[4].TxHash, utxo_60_ada_no_assets.TxHash);        
+        Assert.Equal(response.Inputs[4].TransactionId, utxo_60_ada_no_assets.TxHash.HexToByteArray());
+        Assert.Equal(response.SelectedUtxos.Count, 5);
+        Assert.Equal(response.ChangeOutputs.Count, 2);
     }
 }

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveBasicTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveBasicTests.cs
@@ -26,7 +26,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         ulong totalSelected = 0;
@@ -48,7 +48,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -69,7 +69,7 @@ public partial class CIP2Tests
         }
         
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
         
         //assert
         //assert that selected utxo ada value is greater than the requested outputs' ada value
@@ -110,7 +110,7 @@ public partial class CIP2Tests
         }
         
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
         
         //assert
         //assert that selected utxo ada value is greater than the requested outputs' ada value
@@ -153,7 +153,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         ulong totalSelected = 0;
@@ -175,7 +175,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
@@ -196,7 +196,7 @@ public partial class CIP2Tests
         }
         
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
         
         //assert
         //assert that selected utxo ada value is greater than the requested outputs' ada value
@@ -237,7 +237,7 @@ public partial class CIP2Tests
         }
         
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
         
         //assert
         //assert that selected utxo ada value is greater than the requested outputs' ada value

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveBasicTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveBasicTests.cs
@@ -139,10 +139,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_Simple_Test()
+    public void RandomImprove_BasicChange_Simple_Test()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -164,10 +164,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_SingleUtxo_Test()
+    public void RandomImprove_BasicChange_SingleUtxo_Test()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -184,10 +184,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_WithTokens_Test()
+    public void RandomImprove_BasicChange_WithTokens_Test()
     {
         //arrange 
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens };
         var utxos = new List<Utxo>();
         for (var x = 0; x < 10; x++)
@@ -225,10 +225,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_WithTokensAndAda_Test()
+    public void RandomImprove_BasicChange_WithTokensAndAda_Test()
     {
         //arrange 
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens, output_100_ada_no_assets };
         var utxos = new List<Utxo>();
         for (var x = 0; x < 20; x++)

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveBasicTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveBasicTests.cs
@@ -137,4 +137,131 @@ public partial class CIP2Tests
                     +
                     outputs.Sum(x => (long)x.Value.Coin)));
     }
+
+    [Fact]
+    public void RandomImprove_MultiChange_Simple_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_no_assets, utxo_20_ada_no_assets, utxo_30_ada_no_assets, utxo_40_ada_no_assets,
+            utxo_50_ada_no_assets,
+            utxo_60_ada_no_assets, utxo_70_ada_no_assets, utxo_80_ada_no_assets, utxo_90_ada_no_assets,
+            utxo_100_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos);
+
+        //assert
+        ulong totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + s.Balance.Lovelaces);
+        ulong totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + s.Value.Coin);
+        Assert.True(totalSelected == totalChange + output_100_ada_no_assets.Value.Coin);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_SingleUtxo_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos[0].TxHash, utxo_40_ada_no_assets.TxHash);
+        Assert.Equal(response.Inputs[0].TransactionId, utxo_40_ada_no_assets.TxHash.HexToByteArray());
+        Assert.True(response.ChangeOutputs.Count() == 1);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_WithTokens_Test()
+    {
+        //arrange 
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens };
+        var utxos = new List<Utxo>();
+        for (var x = 0; x < 10; x++)
+        {
+            utxos.Add(utxo_10_ada_20_tokens);
+        }
+        
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        
+        //assert
+        //assert that selected utxo ada value is greater than the requested outputs' ada value
+        Assert.True(response.SelectedUtxos.Sum(x => (long)x.Balance.Lovelaces) > outputs.Sum(x => (long)x.Value.Coin));
+        
+        //assert that selected utxo assets equal output + change asset values
+        Assert.Equal(
+            response.SelectedUtxos.Sum(x => 
+                x.Balance.Assets.Where(y => 
+                    y.PolicyId.Equals(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                        ?.Sum(z => (long)z.Quantity) ?? 0), 
+            (response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Sum(y => 
+                    y.Value.Token.Sum(z => (long)z.Value)) ?? 0)
+                    +
+                    outputs.Sum(x =>
+                        x.Value.MultiAsset?.Sum(y => 
+                            y.Value.Token.Sum(z => (long)z.Value)) ?? 0))
+            );
+        
+        //assert that selected utxo ada value equal output + change utxo ada value
+        Assert.Equal(response.SelectedUtxos.Sum(x => (long) x.Balance.Lovelaces), 
+            (response.ChangeOutputs.Sum(x => (long)x.Value.Coin) 
+                    +
+                    outputs.Sum(x => (long)x.Value.Coin)));
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_WithTokensAndAda_Test()
+    {
+        //arrange 
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens, output_100_ada_no_assets };
+        var utxos = new List<Utxo>();
+        for (var x = 0; x < 20; x++)
+        {
+            utxos.Add(utxo_10_ada_20_tokens);
+        }
+        
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        
+        //assert
+        //assert that selected utxo ada value is greater than the requested outputs' ada value
+        Assert.True(response.SelectedUtxos.Sum(x => (long)x.Balance.Lovelaces) > outputs.Sum(x => (long)x.Value.Coin));
+        
+        //assert that selected utxo assets equal output + change asset values
+        Assert.Equal(
+            response.SelectedUtxos.Sum(x => 
+                x.Balance.Assets.Where(y => 
+                    y.PolicyId.Equals(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                        ?.Sum(z => (long)z.Quantity) ?? 0), 
+            (response.ChangeOutputs.Sum(x => 
+                x.Value.MultiAsset?.Sum(y => 
+                    y.Value.Token.Sum(z => (long)z.Value)) ?? 0)
+                    +
+                    outputs.Sum(x =>
+                        x.Value.MultiAsset?.Sum(y => 
+                            y.Value.Token.Sum(z => (long)z.Value)) ?? 0))
+            );
+        
+        //assert that selected utxo ada value equal output + change utxo ada value
+        Assert.Equal(response.SelectedUtxos.Sum(x => (long) x.Balance.Lovelaces), 
+            (response.ChangeOutputs.Sum(x => (long)x.Value.Coin) 
+                    +
+                    outputs.Sum(x => (long)x.Value.Coin)));
+    }
 }

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveBurnTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveBurnTests.cs
@@ -23,7 +23,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -63,7 +63,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -102,7 +102,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -158,7 +158,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -221,7 +221,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -302,7 +302,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveFeeTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveFeeTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CardanoSharp.Wallet.CIPs.CIP2;
+using CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies;
+using CardanoSharp.Wallet.Extensions;
+using CardanoSharp.Wallet.Models;
+using CardanoSharp.Wallet.Models.Transactions;
+using Xunit;
+
+namespace CardanoSharp.Wallet.Test.CIPs;
+
+public partial class CIP2Tests
+{
+    [Fact]
+    public void RandomImprove_Simple_Fee_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new SingleTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_50_ada_no_assets, 
+            utxo_50_ada_no_assets,
+            utxo_10_ada_no_assets,
+            utxo_20_ada_no_assets,
+        };
+
+        //act
+        ulong feeBuffer = 21 * adaToLovelace;
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: feeBuffer);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+        long finalChangeOutputChange = (long)response.ChangeOutputs.Last().Value.Coin;
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.True((ulong)finalChangeOutputChange >= feeBuffer);
+    }
+
+    [Fact]
+    public void RandomImprove_Simple_Fee_Fail_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new SingleTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_50_ada_no_assets, 
+            utxo_50_ada_no_assets,
+            utxo_10_ada_no_assets,
+        };
+
+        //assert
+        try
+        {
+            //act
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: 11 * adaToLovelace);
+        }
+        catch (Exception e)
+        {
+            //assert
+            Assert.Equal("UTxOs have insufficient balance", e.Message);
+        }
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_Fee_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_10_tokens, 
+            utxo_10_ada_1_owned_mint_asset, 
+            utxo_10_ada_1_owned_mint_asset_two, 
+            utxo_10_ada_100_owned_mint_asset,
+        };
+
+        //act
+        ulong feeBuffer = 3 * adaToLovelace;
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: feeBuffer);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos.Count, 4);
+        Assert.Equal(response.ChangeOutputs.Count, 5);
+
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+        long finalChangeOutputChange = (long)response.ChangeOutputs.Last().Value.Coin;
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.True((ulong)finalChangeOutputChange >= feeBuffer);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_Fee_Test_2()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_10_tokens, 
+            utxo_10_ada_1_owned_mint_asset, 
+            utxo_10_ada_1_owned_mint_asset_two, 
+            utxo_10_ada_100_owned_mint_asset,
+            utxo_10_ada_100_owned_mint_asset_two,
+        };
+
+        //act
+        ulong feeBuffer = 11 * adaToLovelace;
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: 11 * adaToLovelace);
+
+        //assert
+        Assert.Equal(response.SelectedUtxos.Count, 5);
+        Assert.Equal(response.ChangeOutputs.Count, 5);
+        Assert.Equal(response.ChangeOutputs.First().Value.MultiAsset.Count, 2);
+
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+        long finalChangeOutputChange = (long)response.ChangeOutputs.Last().Value.Coin;
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.True((ulong)finalChangeOutputChange >= feeBuffer);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_Fee_Fail_Test()
+    {
+        //arrange
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_50_ada_no_assets, 
+            utxo_50_ada_no_assets,
+            utxo_10_ada_no_assets,
+        };
+
+        //assert
+        try
+        {
+            //act
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, feeBuffer: 11 * adaToLovelace);
+        }
+        catch (Exception e)
+        {
+            //assert
+            Assert.Equal("UTxOs have insufficient balance", e.Message);
+        }
+    }
+}

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveFeeTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveFeeTests.cs
@@ -69,10 +69,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_Fee_Test()
+    public void RandomImprove_BasicChange_Fee_Test()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -88,7 +88,7 @@ public partial class CIP2Tests
 
         //assert
         Assert.Equal(response.SelectedUtxos.Count, 4);
-        Assert.Equal(response.ChangeOutputs.Count, 5);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
 
         long totalSelected = 0;
         response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
@@ -102,10 +102,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_Fee_Test_2()
+    public void RandomImprove_BasicChange_Fee_Test_2()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_no_assets, output_10_ada_no_assets };
         var utxos = new List<Utxo>()
         {
@@ -122,8 +122,8 @@ public partial class CIP2Tests
 
         //assert
         Assert.Equal(response.SelectedUtxos.Count, 5);
-        Assert.Equal(response.ChangeOutputs.Count, 5);
-        Assert.Equal(response.ChangeOutputs.First().Value.MultiAsset.Count, 2);
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+        Assert.Equal(response.ChangeOutputs.First().Value.MultiAsset.Count, 5);
 
         long totalSelected = 0;
         response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
@@ -137,10 +137,10 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_Fee_Fail_Test()
+    public void RandomImprove_BasicChange_Fee_Fail_Test()
     {
         //arrange
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets };
         var utxos = new List<Utxo>()
         {

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
@@ -23,7 +23,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -61,7 +61,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -103,7 +103,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -143,7 +143,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -195,7 +195,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -248,7 +248,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -300,7 +300,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -358,7 +358,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -426,7 +426,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -465,7 +465,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -518,7 +518,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -572,7 +572,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -627,7 +627,7 @@ public partial class CIP2Tests
         try
         {
             //act            
-            var response = coinSelection.GetCoinSelection(outputs, utxos);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address);
         }
         catch (Exception e)
         {
@@ -652,7 +652,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;
@@ -725,7 +725,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
 
         //assert
         long totalSelected = 0;

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
@@ -780,4 +780,774 @@ public partial class CIP2Tests
         Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
         Assert.Equal(selectedUTXOsSumAsset3, outputsSumAsset3 + changeOutputSumAsset3);
     }
+
+    [Fact]
+    public void RandomImprove_MultiChange_SingleUTXO_SingleOutput_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 1, outputsSumAsset1 + changeOutputSumAsset1);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_SingleUTXO_MultiOutput_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 1, outputsSumAsset1 + changeOutputSumAsset1);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MultiUTXO_MultiOutput_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_no_assets,
+            utxo_50_ada_no_assets,
+            utxo_20_ada_no_assets,
+            utxo_30_ada_no_assets,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 1, outputsSumAsset1 + changeOutputSumAsset1);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_WithTokens_Mint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_10_ada_30_tokens, 
+            utxo_10_ada_50_tokens,
+            utxo_50_ada_no_assets,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_50_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 1, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2, outputsSumAsset2 + changeOutputSumAsset2);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_SingleUTXO_SingleOutput_MultiMint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 1, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MultiUTXO_SingleOutput_MultiMint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_50_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 1, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_SingleUTXO_MultiOutput_MultiMint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MultiUTXO_MultiOutput_MultiMint_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_50_tokens, output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_50_ada_no_assets,
+            utxo_10_ada_40_tokens,
+            utxo_10_ada_30_tokens,
+            utxo_60_ada_no_assets,
+            utxo_90_ada_no_assets,
+            utxo_10_ada_10_tokens,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset3 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset3 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset3 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+        Assert.Equal(selectedUTXOsSumAsset3, outputsSumAsset3 + changeOutputSumAsset3);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MintAndOwned_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MintAndOwned_Test_2()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+    }
+
+    [Fact]
+    public void RandomImprove_MulitChange_MintAndOwned_Test_3()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MintAndOwned_Test_4()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_2_already_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_1_owned_mint_asset_two,
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(response.ChangeOutputs.Count, 1);
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MintAndOwned_Test_Fail()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets, output_10_ada_1_already_minted_assets };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+        };
+
+        try
+        {
+            //act            
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        }
+        catch (Exception e)
+        {
+            //assert
+            Assert.Equal("UTxOs have insufficient balance", e.Message);
+        }
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MultiOption_Test()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_100_ada_no_assets, output_10_ada_50_tokens };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_100_owned_mint_asset,
+            utxo_10_ada_40_tokens,
+            utxo_60_ada_no_assets,            
+            utxo_10_ada_20_tokens,            
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset3 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset3 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset3 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+        Assert.Equal(selectedUTXOsSumAsset3, outputsSumAsset3 + changeOutputSumAsset3);
+    }
+
+    [Fact]
+    public void RandomImprove_MultiChange_MultiOption_Test_2()
+    {
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets, output_100_ada_no_assets, output_10_ada_50_tokens };
+        var utxos = new List<Utxo>()
+        {
+            utxo_40_ada_no_assets,
+            utxo_10_ada_1_owned_mint_asset,
+            utxo_10_ada_100_owned_mint_asset,
+            utxo_10_ada_40_tokens,
+            utxo_60_ada_no_assets,            
+            utxo_10_ada_20_tokens, 
+            utxo_90_ada_no_assets,           
+        };
+
+        //act
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+
+        //assert
+        long totalSelected = 0;
+        response.SelectedUtxos.ForEach(s => totalSelected = totalSelected + (long)s.Balance.Lovelaces);
+        long totalOutput = 0;
+        outputs.ForEach(o => totalOutput = totalOutput + (long)o.Value.Coin);
+        long totalChange = 0;
+        response.ChangeOutputs.ForEach(s => totalChange = totalChange + (long)s.Value.Coin);
+
+        var selectedUTXOsSumAsset1 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset1 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset1 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset2 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset2 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset2 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var selectedUTXOsSumAsset3 = response.SelectedUtxos.Where(x => x.Balance.Assets is not null).Sum(x => 
+            x.Balance.Assets.Where(y => 
+                y.PolicyId.Equals(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId))
+                    ?.Sum(z => (long)z.Quantity) ?? 0);
+
+        var outputsSumAsset3 = outputs.Sum(x =>
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        var changeOutputSumAsset3 = response.ChangeOutputs.Sum(x => 
+            x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
+                y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_40_tokens.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
+
+        Assert.Equal(totalSelected, totalOutput + totalChange);
+        Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
+        Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);
+        Assert.Equal(selectedUTXOsSumAsset3, outputsSumAsset3 + changeOutputSumAsset3);
+    }    
 }

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
@@ -826,9 +826,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_SingleUTXO_SingleOutput_Mint_Test()
+    public void RandomImprove_BasicChange_SingleUTXO_SingleOutput_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -864,9 +864,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_SingleUTXO_MultiOutput_Mint_Test()
+    public void RandomImprove_BasicChange_SingleUTXO_MultiOutput_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_no_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -902,9 +902,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MultiUTXO_MultiOutput_Mint_Test()
+    public void RandomImprove_BasicChange_MultiUTXO_MultiOutput_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -944,9 +944,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_WithTokens_Mint_Test()
+    public void RandomImprove_BasicChange_WithTokens_Mint_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_50_tokens, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -998,9 +998,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_SingleUTXO_SingleOutput_MultiMint_Test()
+    public void RandomImprove_BasicChange_SingleUTXO_SingleOutput_MultiMint_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1050,9 +1050,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MultiUTXO_SingleOutput_MultiMint_Test()
+    public void RandomImprove_BasicChange_MultiUTXO_SingleOutput_MultiMint_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1103,9 +1103,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_SingleUTXO_MultiOutput_MultiMint_Test()
+    public void RandomImprove_BasicChange_SingleUTXO_MultiOutput_MultiMint_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1155,9 +1155,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MultiUTXO_MultiOutput_MultiMint_Test()
+    public void RandomImprove_BasicChange_MultiUTXO_MultiOutput_MultiMint_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_100_ada_no_assets, output_10_ada_50_tokens, output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1227,9 +1227,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MintAndOwned_Test()
+    public void RandomImprove_BasicChange_MintAndOwned_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_1_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1270,9 +1270,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MintAndOwned_Test_2()
+    public void RandomImprove_BasicChange_MintAndOwned_Test_2()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1325,7 +1325,7 @@ public partial class CIP2Tests
     [Fact]
     public void RandomImprove_MulitChange_MintAndOwned_Test_3()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1377,9 +1377,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MintAndOwned_Test_4()
+    public void RandomImprove_BasicChange_MintAndOwned_Test_4()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_2_already_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1432,9 +1432,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MintAndOwned_Test_Fail()
+    public void RandomImprove_BasicChange_MintAndOwned_Test_Fail()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets, output_10_ada_1_already_minted_assets };
         var utxos = new List<Utxo>()
         {
@@ -1455,9 +1455,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MultiOption_Test()
+    public void RandomImprove_BasicChange_MultiOption_Test()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_100_ada_no_assets, output_10_ada_50_tokens };
         var utxos = new List<Utxo>()
         {
@@ -1526,9 +1526,9 @@ public partial class CIP2Tests
     }
 
     [Fact]
-    public void RandomImprove_MultiChange_MultiOption_Test_2()
+    public void RandomImprove_BasicChange_MultiOption_Test_2()
     {
-        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+        var coinSelection = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
         var outputs = new List<TransactionOutput>() { output_10_ada_2_minted_assets, output_10_ada_1_minted_assets, output_10_ada_1_already_minted_assets, output_100_ada_no_assets, output_10_ada_50_tokens };
         var utxos = new List<Utxo>()
         {

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
@@ -6,6 +6,7 @@ using CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies;
 using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Models;
 using CardanoSharp.Wallet.Models.Transactions;
+using CardanoSharp.Wallet.TransactionBuilding;
 using Xunit;
 
 namespace CardanoSharp.Wallet.Test.CIPs;
@@ -23,7 +24,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -61,7 +62,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -103,7 +104,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -143,7 +144,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -194,8 +195,12 @@ public partial class CIP2Tests
             utxo_40_ada_no_assets,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -247,8 +252,12 @@ public partial class CIP2Tests
             utxo_50_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 1);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -299,8 +308,12 @@ public partial class CIP2Tests
             utxo_40_ada_no_assets
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -357,8 +370,12 @@ public partial class CIP2Tests
             utxo_10_ada_10_tokens,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -425,8 +442,11 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -464,8 +484,12 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -517,8 +541,12 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -571,8 +599,12 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset_two,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -624,10 +656,14 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         try
         {
             //act            
-            var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
         }
         catch (Exception e)
         {
@@ -651,8 +687,12 @@ public partial class CIP2Tests
             utxo_10_ada_20_tokens,            
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -724,8 +764,12 @@ public partial class CIP2Tests
             utxo_90_ada_no_assets,           
         };
 
+        TokenBundleBuilder mint_and_burn_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_and_burn_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+        mint_and_burn_tokens.AddToken(mint_policy_2.HexToByteArray(), mint_policy_2_asset_1.ToBytes(), 1);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_and_burn_tokens);
 
         //assert
         long totalSelected = 0;
@@ -792,7 +836,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -830,7 +874,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -872,7 +916,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -912,7 +956,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_1_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -964,7 +1008,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_2_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -1017,7 +1061,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_2_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -1069,7 +1113,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -1127,7 +1171,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -1193,8 +1237,11 @@ public partial class CIP2Tests
             utxo_10_ada_1_owned_mint_asset,
         };
 
+        TokenBundleBuilder mint_tokens = (TokenBundleBuilder)TokenBundleBuilder.Create;
+        mint_tokens.AddToken(mint_policy_1.HexToByteArray(), mint_policy_1_asset_1.ToBytes(), 2);
+
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_tokens);
 
         //assert
         long totalSelected = 0;
@@ -1234,7 +1281,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -1287,7 +1334,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -1342,7 +1389,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -1398,7 +1445,7 @@ public partial class CIP2Tests
         try
         {
             //act            
-            var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+            var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
         }
         catch (Exception e)
         {
@@ -1423,7 +1470,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
 
         //assert
         long totalSelected = 0;
@@ -1495,7 +1542,7 @@ public partial class CIP2Tests
         };
 
         //act
-        var response = coinSelection.GetCoinSelection(outputs, utxos, address);
+        var response = coinSelection.GetCoinSelection(outputs, utxos, address, mint_3_token_1_quantity);
 
         //assert
         long totalSelected = 0;

--- a/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP2Tests/RandomImproveTests/RandomImproveMintTests.cs
@@ -1270,7 +1270,6 @@ public partial class CIP2Tests
             x.Value.MultiAsset?.Where(y => y.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().PolicyId)).Sum(y => 
                 y.Value.Token.Where(z => z.Key.ToStringHex().SequenceEqual(utxo_10_ada_1_owned_mint_asset_two.Balance.Assets.FirstOrDefault().Name)).Sum(z => (long)z.Value)) ?? 0);
 
-        Assert.Equal(response.ChangeOutputs.Count, 1);
         Assert.Equal(totalSelected, totalOutput + totalChange);
         Assert.Equal(selectedUTXOsSumAsset1 + 2, outputsSumAsset1 + changeOutputSumAsset1);
         Assert.Equal(selectedUTXOsSumAsset2 + 1, outputsSumAsset2 + changeOutputSumAsset2);

--- a/CardanoSharp.Wallet.Test/TransactionOutputTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionOutputTests.cs
@@ -34,7 +34,7 @@ namespace CardanoSharp.Wallet.Test
                 .AddToken(getGenesisPolicyId(), "00010203".HexToByteArray(), 60)
                 .AddToken(getGenesisPolicyId(), "00010204".HexToByteArray(), 240);
 
-            Assert.Equal((ulong)1374890, tokenBundle1.Build().CalculateMinUtxoLovelace());
+            Assert.Equal((ulong)1172320, tokenBundle1.Build().CalculateMinUtxoLovelace());
 
             var tokenBundle2 = TokenBundleBuilder.Create
                 .AddToken(getGenesisPolicyId(), "00010205".HexToByteArray(), 60)
@@ -42,7 +42,7 @@ namespace CardanoSharp.Wallet.Test
                 .AddToken(getGenesisPolicyId(), "00010207".HexToByteArray(), 180)
                 .AddToken(getGenesisPolicyId(), "00010208".HexToByteArray(), 240);
 
-            Assert.Equal((ulong)1435230, tokenBundle2.Build().CalculateMinUtxoLovelace());
+            Assert.Equal((ulong)1232660, tokenBundle2.Build().CalculateMinUtxoLovelace());
         }
 
         [Fact]

--- a/CardanoSharp.Wallet.Test/TransactionTests.cs
+++ b/CardanoSharp.Wallet.Test/TransactionTests.cs
@@ -303,7 +303,7 @@ namespace CardanoSharp.Wallet.Test
             var expectedTrans = TransactionBuilder.Create
                 .SetBody(TransactionBodyBuilder.Create
                     .AddInput(input1TxHash, 1)
-                    .AddOutput(payment1Addr, 1, OutputPurpose.Spend, tokenBundle1)
+                    .AddOutput(payment1Addr, 1, tokenBundle1, OutputPurpose.Spend)
                     .SetFee(171397)
                     .SetTtl(57910820)
                     .SetCertificate(CertificateBuilder.Create
@@ -355,7 +355,7 @@ namespace CardanoSharp.Wallet.Test
             var expected = TransactionBuilder.Create
                 .SetBody(TransactionBodyBuilder.Create
                     .AddInput(input1TxHash, 1)
-                    .AddOutput(payment1Addr, 1, OutputPurpose.Spend, tokenBundle1)
+                    .AddOutput(payment1Addr, 1, tokenBundle1, OutputPurpose.Spend)
                     .SetFee(171397)
                     .SetTtl(57910820)
                     .SetCertificate(CertificateBuilder.Create
@@ -717,8 +717,8 @@ namespace CardanoSharp.Wallet.Test
             var transactionBody = TransactionBodyBuilder.Create
                 .AddInput(getGenesisTransaction(), 0)
                 .AddInput(getGenesisTransaction(), 0)
-                .AddOutput(baseAddr, 1, OutputPurpose.Spend, tokenBundle1)
-                .AddOutput(changeAddr, 18, OutputPurpose.Spend, tokenBundle2)
+                .AddOutput(baseAddr, 1, tokenBundle1, OutputPurpose.Spend)
+                .AddOutput(changeAddr, 18, tokenBundle2, OutputPurpose.Spend)
                 .SetFee(1)
                 .Build();
 
@@ -752,7 +752,7 @@ namespace CardanoSharp.Wallet.Test
             //This should do the same
             var withEmptyTokenBundle = TransactionBodyBuilder.Create
                 .AddInput(getGenesisTransaction(), 0)
-                .AddOutput(baseAddr, 1, OutputPurpose.Spend, TokenBundleBuilder.Create)
+                .AddOutput(baseAddr, 1, TokenBundleBuilder.Create, OutputPurpose.Spend)
                 .Build();
 
             //act
@@ -792,7 +792,7 @@ namespace CardanoSharp.Wallet.Test
             var transactionBody = TransactionBodyBuilder.Create
                 .AddInput(getGenesisTransaction(), 0)
                 .AddInput(getGenesisTransaction(), 0)
-                .AddOutput(baseAddr, 1, OutputPurpose.Spend, tokenBundle1)
+                .AddOutput(baseAddr, 1, tokenBundle1, OutputPurpose.Spend)
                 .SetFee(1)
                 .Build();
 
@@ -830,7 +830,7 @@ namespace CardanoSharp.Wallet.Test
             var transactionBody = TransactionBodyBuilder.Create
                 .AddInput(getGenesisTransaction(), 0)
                 .AddInput(getGenesisTransaction(), 0)
-                .AddOutput(baseAddr, 1, OutputPurpose.Spend, tokenBundle1)
+                .AddOutput(baseAddr, 1, tokenBundle1, OutputPurpose.Spend)
                 .SetFee(1)
                 .Build();
 
@@ -1038,7 +1038,7 @@ namespace CardanoSharp.Wallet.Test
 
             var transactionBody = TransactionBodyBuilder.Create
                 .AddInput(txInAddr.HexToByteArray(), txInIndex)
-                .AddOutput(baseAddr, 1, OutputPurpose.Mint, mintAsset)
+                .AddOutput(baseAddr, 1,  mintAsset, OutputPurpose.Mint)
                 .SetMint(mintAsset)
                 .SetTtl(1000)
                 .SetFee(0);
@@ -1165,7 +1165,7 @@ namespace CardanoSharp.Wallet.Test
 
             var transactionBody = TransactionBodyBuilder.Create
                 .AddInput(txInAddr.HexToByteArray(), txInIndex)
-                .AddOutput(baseAddr, 1, OutputPurpose.Mint, mintAsset)
+                .AddOutput(baseAddr, 1, mintAsset, OutputPurpose.Mint)
                 .SetMint(mintAsset)
                 .SetTtl(1000)
                 .SetMetadataHash(auxData)

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/BasicChangeSelectionStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/BasicChangeSelectionStrategy.cs
@@ -12,7 +12,7 @@ using CardanoSharp.Wallet.Models.Transactions;
 
 namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
 {
-    public class MultiTokenBundleStrategy: IChangeCreationStrategy
+    public class BasicChangeSelectionStrategy: IChangeCreationStrategy
     {
         public void CalculateChange(CoinSelection coinSelection, Balance outputBalance, string changeAddress, ulong feeBuffer = 0)
         {
@@ -20,60 +20,36 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             coinSelection.ChangeOutputs.Clear();
 
             var inputBalance = coinSelection.SelectedUtxos.AggregateAssets();
-            
-            // ideal change outputs is 4 because the max output size is 5kb
-            // if the max tx size is 16kb, 4 token bundle outputs prevents
-            // all output size errors
-            int idealTokenBundleChangeOutputs = 4;
-            var tokenBundleChangeOutputs = new List<TransactionOutput>();
 
             //calculate change for token bundle
-            int changeOutputIndex = 0;
             foreach (var asset in inputBalance.Assets)
             {
-                TransactionOutput changeOutput = null;
-                if (changeOutputIndex < tokenBundleChangeOutputs.Count)
-                    changeOutput = tokenBundleChangeOutputs[changeOutputIndex];
-
-                TransactionOutput calculatedOutput = CalculateTokenBundleUtxo(coinSelection, asset, outputBalance, changeOutput, changeAddress);
-                if (calculatedOutput is null) 
-                    continue;
-
-
-                if (tokenBundleChangeOutputs.Count < idealTokenBundleChangeOutputs)
-                    tokenBundleChangeOutputs.Add(calculatedOutput);
-                else
-                    tokenBundleChangeOutputs[changeOutputIndex] = calculatedOutput;
-
-                changeOutputIndex += 1;
-                if (changeOutputIndex >= idealTokenBundleChangeOutputs)
-                    changeOutputIndex = 0;
+                CalculateTokenBundleUtxo(coinSelection, asset, outputBalance, changeAddress);
             }
 
-            //determine/calculate the min lovelaces required for the token bundle
+            //determine/calculate the min lovelaces required for the token bundles
             ulong minLovelaces = 0;
-            foreach (var changeOutput in tokenBundleChangeOutputs) {
+            foreach (var changeOutput in coinSelection.ChangeOutputs) {
                 ulong changeLovelaces = changeOutput.CalculateMinUtxoLovelace();
                 minLovelaces += changeLovelaces;
                 changeOutput.Value.Coin = changeLovelaces;
             }
-            coinSelection.ChangeOutputs = tokenBundleChangeOutputs;            
 
-            //calculate ada utxo accounting for selected, requested, and token bundle min 
+            //add remaining ada to the last ouput
             CalculateAdaUtxo(coinSelection, inputBalance.Lovelaces, minLovelaces, outputBalance, changeAddress, feeBuffer);
         }
 
-        public TransactionOutput CalculateTokenBundleUtxo(CoinSelection coinSelection, Asset asset, Balance outputBalance, TransactionOutput changeUtxo, string changeAddress)
+        public void CalculateTokenBundleUtxo(CoinSelection coinSelection, Asset asset, Balance outputBalance, string changeAddress)
         {
             // get quantity of UTxO for current asset
             long currentQuantity = coinSelection.SelectedUtxos
                 .Where(x => x.Balance.Assets is not null)
                 .SelectMany(x => x.Balance.Assets
                     .Where(al =>
-                        al.PolicyId.SequenceEqual(asset.PolicyId) 
+                        al.PolicyId.SequenceEqual(asset.PolicyId)
                         && al.Name.Equals(asset.Name))
                     .Select(x => (long) x.Quantity))
-                .Sum();       
+                .Sum();
 
             var outputQuantity = outputBalance.Assets
                 .Where(x => x.PolicyId.SequenceEqual(asset.PolicyId)
@@ -83,12 +59,12 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
 
             // determine change value for current asset based on requested and how much is selected
             var changeValue = currentQuantity - outputQuantity;
-            if (changeValue <= 0) 
-                return null;
+            if (changeValue <= 0)
+                return;
 
+            var changeUtxo = coinSelection.ChangeOutputs.LastOrDefault(x => x.Value.MultiAsset is not null);
             if (changeUtxo is null)
             {
-                //add if doesnt exist
                 changeUtxo = new TransactionOutput()
                 {
                     Address = new Address(changeAddress).GetBytes(),
@@ -98,6 +74,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
                     },
                     OutputPurpose = OutputPurpose.Change
                 };
+                coinSelection.ChangeOutputs.Add(changeUtxo);
             }
 
             //determine if we already have an asset added with the same policy id
@@ -120,27 +97,65 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
                 policyAsset.Value.Token.Add(asset.Name.HexToByteArray(), changeValue);
             }
 
-            return changeUtxo;
+            // If the changeUTXO is no longer valid, remove the asset that was just added, and create a new output
+            if (!changeUtxo.IsValid()) {
+                var previousMultiAsset = changeUtxo.Value.MultiAsset.Where(x => x.Key.SequenceEqual(asset.PolicyId.HexToByteArray())).FirstOrDefault();
+                var previousToken = previousMultiAsset.Value.Token.Where(x => x.Key.SequenceEqual(asset.Name.HexToByteArray())).FirstOrDefault();
+
+                long newTokenValue = previousToken.Value - changeValue;
+                previousMultiAsset.Value.Token[previousToken.Key] = newTokenValue;
+                if (newTokenValue <= 0) {
+                    previousMultiAsset.Value.Token.Remove(previousToken.Key);
+                }
+
+                if (previousMultiAsset.Value.Token.Count <= 0) {
+                    changeUtxo.Value.MultiAsset.Remove(previousMultiAsset.Key);
+                }
+
+                // Create a new Output and add it to the change outputs
+                var newOutput = new TransactionOutput()
+                {
+                    Address = new Address(changeAddress).GetBytes(),
+                    Value = new TransactionOutputValue()
+                    {
+                        MultiAsset = new Dictionary<byte[], NativeAsset>()
+                    },
+                    OutputPurpose = OutputPurpose.Change
+                };
+
+                newOutput.Value.MultiAsset.Add(asset.PolicyId.HexToByteArray(), new NativeAsset()
+                {
+                    Token = new Dictionary<byte[], long>()
+                    {
+                        {asset.Name.HexToByteArray(), changeValue}
+                    }
+                });
+                coinSelection.ChangeOutputs.Add(newOutput);
+            }
         }
 
         public void CalculateAdaUtxo(CoinSelection coinSelection, ulong ada, ulong tokenBundleMin, Balance outputBalance, string changeAddress, ulong feeBuffer = 0)
         {
             // determine change value for current asset based on requested and how much is selected
-            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces) + (long)feeBuffer);
+            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces)) + (long)feeBuffer; // Add feebuffer to account for it being subtracted in the outputBalance.Lovelaces
             if (changeValue <= 0)
                 return;
 
-            //this is for lovelaces
-            coinSelection.ChangeOutputs.Add(new TransactionOutput()
+            var changeUtxo = coinSelection.ChangeOutputs.LastOrDefault(x => x.Value.MultiAsset is not null);
+            if (changeUtxo is null)
             {
-                Address = new Address(changeAddress).GetBytes(),
-                Value = new TransactionOutputValue()
+                changeUtxo = new TransactionOutput()
                 {
-                    Coin = (ulong)changeValue,
-                    MultiAsset = null,
-                },
-                OutputPurpose = OutputPurpose.Change
-            });   
+                    Address = new Address(changeAddress).GetBytes(),
+                    Value = new TransactionOutputValue()
+                    {
+                        MultiAsset = new Dictionary<byte[], NativeAsset>()
+                    },
+                    OutputPurpose = OutputPurpose.Change
+                };
+                coinSelection.ChangeOutputs.Add(changeUtxo);
+            }
+            changeUtxo.Value.Coin += (ulong)changeValue;
         }
     }
 }

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/IChangeCreationStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/IChangeCreationStrategy.cs
@@ -7,6 +7,6 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
 {
     public interface IChangeCreationStrategy
     {
-        void CalculateChange(CoinSelection coinSelection, Balance balance);
+        void CalculateChange(CoinSelection coinSelection, Balance balance, string changeAddress, ulong fee = 0);
     }
 }

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/IChangeCreationStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/IChangeCreationStrategy.cs
@@ -7,6 +7,6 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
 {
     public interface IChangeCreationStrategy
     {
-        void CalculateChange(CoinSelection coinSelection, Balance balance, string changeAddress, ulong fee = 0);
+        void CalculateChange(CoinSelection coinSelection, Balance balance, string changeAddress, ulong feeBuffer = 0);
     }
 }

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/MultiTokenBundleStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/MultiTokenBundleStrategy.cs
@@ -7,6 +7,7 @@ using CardanoSharp.Wallet.Enums;
 using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Extensions.Models.Transactions;
 using CardanoSharp.Wallet.Models;
+using CardanoSharp.Wallet.Models.Addresses;
 using CardanoSharp.Wallet.Models.Transactions;
 
 namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
@@ -90,7 +91,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
                 //add if doesnt exist
                 changeUtxo = new TransactionOutput()
                 {
-                    Address = changeAddress.ToBytes(),
+                    Address = new Address(changeAddress).GetBytes(),
                     Value = new TransactionOutputValue()
                     {
                         MultiAsset = new Dictionary<byte[], NativeAsset>()
@@ -132,7 +133,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             //this is for lovelaces
             coinSelection.ChangeOutputs.Add(new TransactionOutput()
             {
-                Address = changeAddress.ToBytes(),
+                Address = new Address(changeAddress).GetBytes(),
                 Value = new TransactionOutputValue()
                 {
                     Coin = (ulong)changeValue,

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/MultiTokenBundleStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/MultiTokenBundleStrategy.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CardanoSharp.Wallet.CIPs.CIP2.Extensions;
+using CardanoSharp.Wallet.CIPs.CIP2.Models;
+using CardanoSharp.Wallet.Enums;
+using CardanoSharp.Wallet.Extensions;
+using CardanoSharp.Wallet.Extensions.Models.Transactions;
+using CardanoSharp.Wallet.Models;
+using CardanoSharp.Wallet.Models.Transactions;
+
+namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
+{
+    public class MultiTokenBundleStrategy: IChangeCreationStrategy
+    {
+        public void CalculateChange(CoinSelection coinSelection, Balance outputBalance)
+        {
+            //clear our change output list
+            coinSelection.ChangeOutputs.Clear();
+
+            var inputBalance = coinSelection.SelectedUtxos.AggregateAssets();
+            
+            // ideal change outputs is 4 because the max output size is 5kb
+            // if the max tx size is 16kb, 4 token bundle outputs prevents
+            // all output size errors
+            int idealTokenBundleChangeOutputs = 4;
+            var tokenBundleChangeOutputs = new List<TransactionOutput>();
+
+            //calculate change for token bundle
+            int changeOutputIndex = 0;
+            foreach (var asset in inputBalance.Assets)
+            {
+                TransactionOutput changeOutput = null;
+                if (changeOutputIndex < tokenBundleChangeOutputs.Count)
+                    changeOutput = tokenBundleChangeOutputs[changeOutputIndex];
+
+                TransactionOutput calculatedOutput = CalculateTokenBundleUtxo(coinSelection, asset, outputBalance, changeOutput);
+                if (tokenBundleChangeOutputs.Count < idealTokenBundleChangeOutputs)
+                    tokenBundleChangeOutputs.Add(calculatedOutput);
+                else
+                    tokenBundleChangeOutputs[changeOutputIndex] = calculatedOutput;
+
+                changeOutputIndex += 1;
+                if (changeOutputIndex >= idealTokenBundleChangeOutputs)
+                    changeOutputIndex = 0;
+            }
+
+            //determine/calculate the min lovelaces required for the token bundle
+            ulong minLovelaces = 0;
+            foreach (var changeOutput in tokenBundleChangeOutputs) {
+                ulong changeLovelaces = changeOutput.CalculateMinUtxoLovelace();
+                minLovelaces += changeLovelaces;
+                changeOutput.Value.Coin = changeLovelaces;
+            }
+            coinSelection.ChangeOutputs = tokenBundleChangeOutputs;            
+
+            //calculate ada utxo accounting for selected, requested, and token bundle min 
+            CalculateAdaUtxo(coinSelection, inputBalance.Lovelaces, minLovelaces, outputBalance);
+        }
+
+        public TransactionOutput CalculateTokenBundleUtxo(CoinSelection coinSelection, Asset asset, Balance outputBalance, TransactionOutput changeUtxo)
+        {
+            // get quantity of UTxO for current asset
+            long currentQuantity = coinSelection.SelectedUtxos
+                .Where(x => x.Balance.Assets is not null)
+                .SelectMany(x => x.Balance.Assets
+                    .Where(al =>
+                        al.PolicyId.SequenceEqual(asset.PolicyId) 
+                        && al.Name.Equals(asset.Name))
+                    .Select(x => (long) x.Quantity))
+                .Sum();       
+
+            var outputQuantity = outputBalance.Assets
+                .Where(x => x.PolicyId.SequenceEqual(asset.PolicyId)
+                            && x.Name.Equals(asset.Name))
+                .Select(x => x.Quantity)
+                .Sum();
+
+            // determine change value for current asset based on requested and how much is selected
+            var changeValue = currentQuantity - outputQuantity;
+
+            if (changeUtxo is null)
+            {
+                //add if doesnt exist
+                changeUtxo = new TransactionOutput()
+                {
+                    Value = new TransactionOutputValue()
+                    {
+                        MultiAsset = new Dictionary<byte[], NativeAsset>()
+                    },
+                    OutputPurpose = OutputPurpose.Change
+                };
+            }
+
+            //determine if we already have an asset added with the same policy id
+            var multiAsset = changeUtxo.Value.MultiAsset.Where(x => x.Key.SequenceEqual(asset.PolicyId.HexToByteArray()));
+            if (!multiAsset.Any())
+            {
+                //add policy and asset to token bundle
+                changeUtxo.Value.MultiAsset.Add(asset.PolicyId.HexToByteArray(), new NativeAsset()
+                {
+                    Token = new Dictionary<byte[], long>()
+                    {
+                        {asset.Name.HexToByteArray(), changeValue}
+                    }
+                });
+            }
+            else
+            {
+                //policy already exists in token bundle, just add the asset
+                var policyAsset = multiAsset.FirstOrDefault();
+                policyAsset.Value.Token.Add(asset.Name.HexToByteArray(), changeValue);
+            }
+
+            return changeUtxo;
+        }
+
+        public void CalculateAdaUtxo(CoinSelection coinSelection, ulong ada, ulong tokenBundleMin, Balance outputBalance)
+        {
+            // determine change value for current asset based on requested and how much is selected
+            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces));
+
+            //this is for lovelaces
+            coinSelection.ChangeOutputs.Add(new TransactionOutput()
+            {
+                Value = new TransactionOutputValue()
+                {
+                    Coin = (ulong)changeValue,
+                    MultiAsset = null,
+                },
+                OutputPurpose = OutputPurpose.Change
+            });   
+        }
+    }
+}

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/MultiTokenBundleStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/MultiTokenBundleStrategy.cs
@@ -35,6 +35,10 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
                     changeOutput = tokenBundleChangeOutputs[changeOutputIndex];
 
                 TransactionOutput calculatedOutput = CalculateTokenBundleUtxo(coinSelection, asset, outputBalance, changeOutput, changeAddress);
+                if (calculatedOutput is null) 
+                    continue;
+
+
                 if (tokenBundleChangeOutputs.Count < idealTokenBundleChangeOutputs)
                     tokenBundleChangeOutputs.Add(calculatedOutput);
                 else
@@ -78,6 +82,8 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
 
             // determine change value for current asset based on requested and how much is selected
             var changeValue = currentQuantity - outputQuantity;
+            if (changeValue <= 0) 
+                return null;
 
             if (changeUtxo is null)
             {
@@ -120,6 +126,8 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
         {
             // determine change value for current asset based on requested and how much is selected
             var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces - fee));
+            if (changeValue <= 0)
+                return;
 
             //this is for lovelaces
             coinSelection.ChangeOutputs.Add(new TransactionOutput()

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/MultiTokenBundleStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/MultiTokenBundleStrategy.cs
@@ -13,7 +13,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
 {
     public class MultiTokenBundleStrategy: IChangeCreationStrategy
     {
-        public void CalculateChange(CoinSelection coinSelection, Balance outputBalance, string changeAddress, ulong fee = 0)
+        public void CalculateChange(CoinSelection coinSelection, Balance outputBalance, string changeAddress, ulong feeBuffer = 0)
         {
             //clear our change output list
             coinSelection.ChangeOutputs.Clear();
@@ -59,7 +59,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             coinSelection.ChangeOutputs = tokenBundleChangeOutputs;            
 
             //calculate ada utxo accounting for selected, requested, and token bundle min 
-            CalculateAdaUtxo(coinSelection, inputBalance.Lovelaces, minLovelaces, outputBalance, changeAddress, fee);
+            CalculateAdaUtxo(coinSelection, inputBalance.Lovelaces, minLovelaces, outputBalance, changeAddress, feeBuffer);
         }
 
         public TransactionOutput CalculateTokenBundleUtxo(CoinSelection coinSelection, Asset asset, Balance outputBalance, TransactionOutput changeUtxo, string changeAddress)
@@ -122,10 +122,10 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             return changeUtxo;
         }
 
-        public void CalculateAdaUtxo(CoinSelection coinSelection, ulong ada, ulong tokenBundleMin, Balance outputBalance, string changeAddress, ulong fee)
+        public void CalculateAdaUtxo(CoinSelection coinSelection, ulong ada, ulong tokenBundleMin, Balance outputBalance, string changeAddress, ulong feeBuffer = 0)
         {
             // determine change value for current asset based on requested and how much is selected
-            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces - fee));
+            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces) + (long)feeBuffer);
             if (changeValue <= 0)
                 return;
 

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/SingleTokenBundleStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/SingleTokenBundleStrategy.cs
@@ -14,7 +14,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
 {
     public class SingleTokenBundleStrategy: IChangeCreationStrategy
     {
-        public void CalculateChange(CoinSelection coinSelection, Balance outputBalance, string changeAddress, ulong fee = 0)
+        public void CalculateChange(CoinSelection coinSelection, Balance outputBalance, string changeAddress, ulong feeBuffer = 0)
         {
             //clear our change output list
             coinSelection.ChangeOutputs.Clear();
@@ -36,7 +36,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             }
 
             //calculate ada utxo accounting for selected, requested, and token bundle min 
-            CalculateAdaUtxo(coinSelection, inputBalance.Lovelaces, minLovelaces, outputBalance, changeAddress, fee);
+            CalculateAdaUtxo(coinSelection, inputBalance.Lovelaces, minLovelaces, outputBalance, changeAddress, feeBuffer);
         }
 
         public void CalculateTokenBundleUtxo(CoinSelection coinSelection, Asset asset, Balance outputBalance, string changeAddress)
@@ -101,10 +101,10 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             }
         }
 
-        public void CalculateAdaUtxo(CoinSelection coinSelection, ulong ada, ulong tokenBundleMin, Balance outputBalance, string address, ulong fee)
+        public void CalculateAdaUtxo(CoinSelection coinSelection, ulong ada, ulong tokenBundleMin, Balance outputBalance, string address, ulong feeBuffer = 0)
         {
             // determine change value for current asset based on requested and how much is selected
-            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces));
+            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces) + (long)feeBuffer);
             if (changeValue <= 0)
                 return;
 

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/SingleTokenBundleStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/SingleTokenBundleStrategy.cs
@@ -20,7 +20,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             coinSelection.ChangeOutputs.Clear();
 
             var inputBalance = coinSelection.SelectedUtxos.AggregateAssets();
-            
+
             //calculate change for token bundle
             foreach (var asset in inputBalance.Assets)
             {
@@ -35,7 +35,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
                 coinSelection.ChangeOutputs.First().Value.Coin = minLovelaces;
             }
 
-            //calculate ada utxo accounting for selected, requested, and token bundle min 
+            //calculate ada utxo accounting for selected, requested, and token bundle min
             CalculateAdaUtxo(coinSelection, inputBalance.Lovelaces, minLovelaces, outputBalance, changeAddress, feeBuffer);
         }
 
@@ -46,10 +46,10 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
                 .Where(x => x.Balance.Assets is not null)
                 .SelectMany(x => x.Balance.Assets
                     .Where(al =>
-                        al.PolicyId.SequenceEqual(asset.PolicyId) 
+                        al.PolicyId.SequenceEqual(asset.PolicyId)
                         && al.Name.Equals(asset.Name))
                     .Select(x => (long) x.Quantity))
-                .Sum();       
+                .Sum();
 
             var outputQuantity = outputBalance.Assets
                 .Where(x => x.PolicyId.SequenceEqual(asset.PolicyId)
@@ -61,7 +61,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             var changeValue = currentQuantity - outputQuantity;
             if (changeValue <= 0)
                 return;
-            
+
             //since this is our token bundle change utxo, it could already exist from previous assets
             var changeUtxo = coinSelection.ChangeOutputs.FirstOrDefault(x => x.Value.MultiAsset is not null);
 
@@ -104,7 +104,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
         public void CalculateAdaUtxo(CoinSelection coinSelection, ulong ada, ulong tokenBundleMin, Balance outputBalance, string address, ulong feeBuffer = 0)
         {
             // determine change value for current asset based on requested and how much is selected
-            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces) + (long)feeBuffer);
+            var changeValue = Math.Abs((long)(ada - tokenBundleMin - outputBalance.Lovelaces)) + (long)feeBuffer;
             if (changeValue <= 0)
                 return;
 

--- a/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/SingleTokenBundleStrategy.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/ChangeCreationStrategies/SingleTokenBundleStrategy.cs
@@ -8,7 +8,7 @@ using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Extensions.Models.Transactions;
 using CardanoSharp.Wallet.Models;
 using CardanoSharp.Wallet.Models.Transactions;
-using CardanoSharp.Wallet.TransactionBuilding;
+using CardanoSharp.Wallet.Models.Addresses;
 
 namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
 {
@@ -70,7 +70,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
                 //add if doesnt exist
                 changeUtxo = new TransactionOutput()
                 {
-                    Address = changeAddress.ToBytes(),
+                    Address = new Address(changeAddress).GetBytes(),
                     Value = new TransactionOutputValue()
                     {
                         MultiAsset = new Dictionary<byte[], NativeAsset>()
@@ -111,6 +111,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies
             //this is for lovelaces
             coinSelection.ChangeOutputs.Add(new TransactionOutput()
             {
+                Address = new Address(address).GetBytes(),
                 Value = new TransactionOutputValue()
                 {
                     Coin = (ulong)changeValue,

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionService.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionService.cs
@@ -7,12 +7,13 @@ using CardanoSharp.Wallet.CIPs.CIP2.Models;
 using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Models;
 using CardanoSharp.Wallet.Models.Transactions;
+using CardanoSharp.Wallet.TransactionBuilding;
 
 namespace CardanoSharp.Wallet.CIPs.CIP2
 {
     public interface ICoinSelectionService
     {
-        CoinSelection GetCoinSelection(IEnumerable<TransactionOutput> outputs, IEnumerable<Utxo> utxos, string changeAddress, int limit = 20, ulong fee = 0);
+        CoinSelection GetCoinSelection(IEnumerable<TransactionOutput> outputs, IEnumerable<Utxo> utxos, string changeAddress, ITokenBundleBuilder mint = null, int limit = 20, ulong fee = 0);
     }
     
     public class CoinSelectionService: ICoinSelectionService
@@ -26,13 +27,13 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
             _changeCreation = changeCreation;
         }
 
-        public CoinSelection GetCoinSelection(IEnumerable<TransactionOutput> outputs, IEnumerable<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
+        public CoinSelection GetCoinSelection(IEnumerable<TransactionOutput> outputs, IEnumerable<Utxo> utxos, string changeAddress, ITokenBundleBuilder mint = null, int limit = 20, ulong feeBuffer = 0)
         {
             var coinSelection = new CoinSelection();
             var availableUTxOs = new List<Utxo>(utxos);
 
             //use balance with mint to select change outputs and balancing without mint to select inputs
-            var balance = outputs.AggregateAssets(feeBuffer);            
+            var balance = outputs.AggregateAssets(mint, feeBuffer);            
 
             foreach (var asset in balance.Assets)
             {

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionService.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionService.cs
@@ -5,6 +5,7 @@ using CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies;
 using CardanoSharp.Wallet.CIPs.CIP2.Extensions;
 using CardanoSharp.Wallet.CIPs.CIP2.Models;
 using CardanoSharp.Wallet.Extensions;
+using CardanoSharp.Wallet.Extensions.Models.Transactions;
 using CardanoSharp.Wallet.Models;
 using CardanoSharp.Wallet.Models.Transactions;
 using CardanoSharp.Wallet.TransactionBuilding;
@@ -13,9 +14,9 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
 {
     public interface ICoinSelectionService
     {
-        CoinSelection GetCoinSelection(IEnumerable<TransactionOutput> outputs, IEnumerable<Utxo> utxos, string changeAddress, ITokenBundleBuilder mint = null, int limit = 20, ulong fee = 0);
+        CoinSelection GetCoinSelection(IEnumerable<TransactionOutput> outputs, IEnumerable<Utxo> utxos, string changeAddress, ITokenBundleBuilder mint = null, int limit = 20, ulong feeBuffer = 0);
     }
-    
+
     public class CoinSelectionService: ICoinSelectionService
     {
         private readonly ICoinSelectionStrategy _coinSelection;
@@ -33,8 +34,9 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
             var availableUTxOs = new List<Utxo>(utxos);
 
             //use balance with mint to select change outputs and balancing without mint to select inputs
-            var balance = outputs.AggregateAssets(mint, feeBuffer);            
+            var balance = outputs.AggregateAssets(mint, feeBuffer);
 
+            //perform initial selection of multi assets and ada
             foreach (var asset in balance.Assets)
             {
                 _coinSelection.SelectInputs(coinSelection, availableUTxOs, asset.Quantity, asset, limit);
@@ -42,16 +44,36 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
                 if (!HasSufficientBalance(coinSelection.SelectedUtxos, asset.Quantity, asset))
                     throw new Exception("UTxOs have insufficient balance");
             }
-            
-            //we need to determine if we have any change for tokens. this way we can accommodate the min lovelaces in our current value
-            if(coinSelection.SelectedUtxos.Any() && _changeCreation is not null) _changeCreation.CalculateChange(coinSelection, balance, changeAddress, feeBuffer);
-            
             _coinSelection.SelectInputs(coinSelection, availableUTxOs, (long)balance.Lovelaces, null, limit);
-            
             if (!HasSufficientBalance(coinSelection.SelectedUtxos, (long)balance.Lovelaces, null))
                 throw new Exception("UTxOs have insufficient balance");
-            
-            if(_changeCreation is not null) _changeCreation.CalculateChange(coinSelection, balance, changeAddress, feeBuffer);
+
+            //we need to determine if we have any change for tokens. this way we can accommodate the min lovelaces in our current value
+            if(coinSelection.SelectedUtxos.Any() && _changeCreation is not null) _changeCreation.CalculateChange(coinSelection, balance, changeAddress, feeBuffer: feeBuffer);
+
+            //calculate change ada from ouputs (not the current change in the coinSelection) and the minium required change ada
+            long change = CalculateChangeADA(coinSelection, balance, feeBuffer);
+            long minChangeAdaRequired = CalculateMinChangeADARequired(coinSelection, feeBuffer);
+
+            //perform additional input selection until we have enough ada to cover the new min amounts (since they change each selction) or we run out of inputs
+            while (change < minChangeAdaRequired && availableUTxOs.Count > 0) {
+
+                //feeBuffer is already in this calculation from minChangeAdaRequired
+                long minADA = (minChangeAdaRequired - change) + coinSelection.SelectedUtxos.Select(x => (long)x.Balance.Lovelaces).Sum();
+
+                _coinSelection.SelectInputs(coinSelection, availableUTxOs, minADA, null, limit);
+                if (!HasSufficientBalance(coinSelection.SelectedUtxos, minADA, null))
+                    throw new Exception("UTxOs have insufficient balance");
+
+                if(_changeCreation is not null) _changeCreation.CalculateChange(coinSelection, balance, changeAddress, feeBuffer: feeBuffer);
+
+                change = CalculateChangeADA(coinSelection, balance, feeBuffer);
+                minChangeAdaRequired = CalculateMinChangeADARequired(coinSelection, feeBuffer);
+            }
+
+            //final check to ensure we have a valid transaction
+            if (change < minChangeAdaRequired && availableUTxOs.Count <= 0)
+                throw new Exception("UTxOs have insufficient balance");
 
             PopulateInputList(coinSelection);
 
@@ -81,6 +103,24 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
             }
 
             return totalInput >= amount;
+        }
+
+        private long CalculateChangeADA(CoinSelection coinSelection, Balance balance, ulong feeBuffer = 0) {
+            long inputADA = coinSelection.SelectedUtxos.Select(x => (long)x.Balance.Lovelaces).Sum();
+            long outputADA = (long)balance.Lovelaces - (long)feeBuffer; // Subtract feebuffer to get the real outputADA amount
+            long change = inputADA - outputADA;
+            if (change <= 0)
+                change = 0;
+            return change;
+        }
+
+        private long CalculateMinChangeADARequired(CoinSelection coinSelection, ulong feeBuffer = 0)
+        {
+            long minChangeADARequired = (long)feeBuffer; // Ensure we have enough ada equal to the min required + fee buffer
+            foreach (var changeOutput in coinSelection.ChangeOutputs) {
+                minChangeADARequired += (long)changeOutput.CalculateMinUtxoLovelace();
+            }
+            return minChangeADARequired;
         }
 
         private void PopulateInputList(CoinSelection coinSelection)

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionService.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionService.cs
@@ -7,7 +7,6 @@ using CardanoSharp.Wallet.CIPs.CIP2.Models;
 using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Models;
 using CardanoSharp.Wallet.Models.Transactions;
-using CardanoSharp.Wallet.TransactionBuilding;
 
 namespace CardanoSharp.Wallet.CIPs.CIP2
 {
@@ -27,13 +26,13 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
             _changeCreation = changeCreation;
         }
 
-        public CoinSelection GetCoinSelection(IEnumerable<TransactionOutput> outputs, IEnumerable<Utxo> utxos, string changeAddress, int limit = 20, ulong fee = 0)
+        public CoinSelection GetCoinSelection(IEnumerable<TransactionOutput> outputs, IEnumerable<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
         {
             var coinSelection = new CoinSelection();
             var availableUTxOs = new List<Utxo>(utxos);
 
             //use balance with mint to select change outputs and balancing without mint to select inputs
-            var balance = outputs.AggregateAssets(fee);            
+            var balance = outputs.AggregateAssets(feeBuffer);            
 
             foreach (var asset in balance.Assets)
             {
@@ -44,14 +43,14 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
             }
             
             //we need to determine if we have any change for tokens. this way we can accommodate the min lovelaces in our current value
-            if(coinSelection.SelectedUtxos.Any() && _changeCreation is not null) _changeCreation.CalculateChange(coinSelection, balance, changeAddress, fee);
+            if(coinSelection.SelectedUtxos.Any() && _changeCreation is not null) _changeCreation.CalculateChange(coinSelection, balance, changeAddress, feeBuffer);
             
             _coinSelection.SelectInputs(coinSelection, availableUTxOs, (long)balance.Lovelaces, null, limit);
             
             if (!HasSufficientBalance(coinSelection.SelectedUtxos, (long)balance.Lovelaces, null))
                 throw new Exception("UTxOs have insufficient balance");
             
-            if(_changeCreation is not null) _changeCreation.CalculateChange(coinSelection, balance, changeAddress, fee);
+            if(_changeCreation is not null) _changeCreation.CalculateChange(coinSelection, balance, changeAddress, feeBuffer);
 
             PopulateInputList(coinSelection);
 

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
@@ -12,14 +12,14 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
     {
         public static CoinSelection UseLargestFirst(this TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, ITokenBundleBuilder mint = null, int limit = 20, ulong feeBuffer = 0)
         {
-            var cs = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
+            var cs = new CoinSelectionService(new LargestFirstStrategy(), new BasicChangeSelectionStrategy());
             var tb = tbb.Build();
             return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, mint, limit, feeBuffer);
         }
 
         public static CoinSelection UseRandomImprove(this TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, ITokenBundleBuilder mint = null, int limit = 20, ulong feeBuffer = 0)
         {
-            var cs = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
+            var cs = new CoinSelectionService(new RandomImproveStrategy(), new BasicChangeSelectionStrategy());
             var tb = tbb.Build();
             return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, mint, limit, feeBuffer);
         }

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
@@ -10,18 +10,18 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
 {
     public static class CoinSelectionUtility
     {
-        public static CoinSelection UseLargestFirst(TransactionBodyBuilder tbb, List<Utxo> utxos)
+        public static CoinSelection UseLargestFirst(TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong fee = 0)
         {
-            var cs = new CoinSelectionService(new LargestFirstStrategy(), new SingleTokenBundleStrategy());
+            var cs = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
             var tb = tbb.Build();
-            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos);
+            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, fee);
         }
 
-        public static CoinSelection UseRandomImprove(TransactionBodyBuilder tbb, List<Utxo> utxos)
+        public static CoinSelection UseRandomImprove(TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong fee = 0)
         {
-            var cs = new CoinSelectionService(new RandomImproveStrategy(), new SingleTokenBundleStrategy());
+            var cs = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
             var tb = tbb.Build();
-            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos);
+            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, fee);
         }
     }
 }

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
@@ -10,14 +10,14 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
 {
     public static class CoinSelectionUtility
     {
-        public static CoinSelection UseLargestFirst(TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
+        public static CoinSelection UseLargestFirst(this TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
         {
             var cs = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
             var tb = tbb.Build();
             return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, feeBuffer);
         }
 
-        public static CoinSelection UseRandomImprove(TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
+        public static CoinSelection UseRandomImprove(this TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
         {
             var cs = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
             var tb = tbb.Build();

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
@@ -10,18 +10,18 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
 {
     public static class CoinSelectionUtility
     {
-        public static CoinSelection UseLargestFirst(this TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
+        public static CoinSelection UseLargestFirst(this TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, ITokenBundleBuilder mint = null, int limit = 20, ulong feeBuffer = 0)
         {
             var cs = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
             var tb = tbb.Build();
-            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, feeBuffer);
+            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, mint, limit, feeBuffer);
         }
 
-        public static CoinSelection UseRandomImprove(this TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
+        public static CoinSelection UseRandomImprove(this TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, ITokenBundleBuilder mint = null, int limit = 20, ulong feeBuffer = 0)
         {
             var cs = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
             var tb = tbb.Build();
-            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, feeBuffer);
+            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, mint, limit, feeBuffer);
         }
     }
 }

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
@@ -10,18 +10,18 @@ namespace CardanoSharp.Wallet.CIPs.CIP2
 {
     public static class CoinSelectionUtility
     {
-        public static CoinSelection UseLargestFirst(TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong fee = 0)
+        public static CoinSelection UseLargestFirst(TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
         {
             var cs = new CoinSelectionService(new LargestFirstStrategy(), new MultiTokenBundleStrategy());
             var tb = tbb.Build();
-            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, fee);
+            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, feeBuffer);
         }
 
-        public static CoinSelection UseRandomImprove(TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong fee = 0)
+        public static CoinSelection UseRandomImprove(TransactionBodyBuilder tbb, List<Utxo> utxos, string changeAddress, int limit = 20, ulong feeBuffer = 0)
         {
             var cs = new CoinSelectionService(new RandomImproveStrategy(), new MultiTokenBundleStrategy());
             var tb = tbb.Build();
-            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, fee);
+            return cs.GetCoinSelection(tb.TransactionOutputs.ToList(), utxos, changeAddress, limit, feeBuffer);
         }
     }
 }

--- a/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/CoinSelectionUtility.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using CardanoSharp.Wallet.CIPs.CIP2.ChangeCreationStrategies;
 using CardanoSharp.Wallet.CIPs.CIP2.Models;
 using CardanoSharp.Wallet.Models;
-using CardanoSharp.Wallet.Models.Transactions;
 using CardanoSharp.Wallet.TransactionBuilding;
 
 namespace CardanoSharp.Wallet.CIPs.CIP2

--- a/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
@@ -1,15 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using CardanoSharp.Wallet.Enums;
 using CardanoSharp.Wallet.Extensions;
 using CardanoSharp.Wallet.Models;
 using CardanoSharp.Wallet.Models.Transactions;
+using CardanoSharp.Wallet.TransactionBuilding;
 
 namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
 {
     public static partial class TransactionOutputExtensions
     {
-        public static Balance AggregateAssets(this IEnumerable<TransactionOutput> transactionOutputs, ulong feeBuffer = 0)
+        public static Balance AggregateAssets(this IEnumerable<TransactionOutput> transactionOutputs, ITokenBundleBuilder mint = null, ulong feeBuffer = 0)
         {
             Balance balance = new Balance()
             {
@@ -24,14 +24,13 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
 
                 //aggregate native assets
                 if(o.Value.MultiAsset is null) continue;
-                if(o.OutputPurpose == OutputPurpose.Mint) continue;
                 
                 foreach (var ma in o.Value.MultiAsset)
                 {
                     foreach (var na in ma.Value.Token)
                     {
                         var nativeAsset = balance.Assets.FirstOrDefault(x =>
-                            x.PolicyId.Equals(ma.Key.ToStringHex()) && x.Name.Equals(na.Key.ToStringHex()));
+                            x.PolicyId.SequenceEqual(ma.Key.ToStringHex()) && x.Name.Equals(na.Key.ToStringHex()));
                         if (nativeAsset is null)
                         {
                             nativeAsset = new Asset()
@@ -43,15 +42,43 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
                             balance.Assets.Add(nativeAsset);
                         }
 
-                        if(o.OutputPurpose == OutputPurpose.Burn) {
-                            nativeAsset.Quantity = nativeAsset.Quantity - na.Value;
-                        }
-                        else {
-                            nativeAsset.Quantity = nativeAsset.Quantity + na.Value;
-                        }                        
+                        nativeAsset.Quantity = nativeAsset.Quantity + na.Value;                       
                     }
                 }
             }
+
+             // remove / add assets from balance based on mint / burn token bundle
+            if (mint is not null) {
+                var mintAssets = mint.Build();
+                foreach (var ma  in mintAssets) {
+                    foreach (var na in ma.Value.Token) {
+                        var nativeAsset = balance.Assets.FirstOrDefault(x =>
+                            x.PolicyId.SequenceEqual(ma.Key.ToStringHex()) && 
+                            x.Name.Equals(na.Key.ToStringHex()));
+                        if (nativeAsset is not null)
+                        {
+                            // remove native asset value from balance, if burning tokens, this will add to the balance
+                            nativeAsset.Quantity = nativeAsset.Quantity - na.Value;
+                            if (nativeAsset.Quantity <= 0) {
+                                balance.Assets.Remove(nativeAsset);
+                            }
+                        }
+                        else {
+                            long quantity = -na.Value; // Only add a required balance asset if an NFT is being burned
+                            if (quantity > 0)
+                            {
+                                nativeAsset = new Asset()
+                                {
+                                    PolicyId = ma.Key.ToStringHex(),
+                                    Name = na.Key.ToStringHex(),
+                                    Quantity = quantity
+                                };
+                                balance.Assets.Add(nativeAsset);
+                            }
+                        }
+                    }                
+                }
+            }   
             
             return balance;
         }

--- a/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
@@ -24,7 +24,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
 
                 //aggregate native assets
                 if(o.Value.MultiAsset is null) continue;
-                
+
                 foreach (var ma in o.Value.MultiAsset)
                 {
                     foreach (var na in ma.Value.Token)
@@ -42,18 +42,18 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
                             balance.Assets.Add(nativeAsset);
                         }
 
-                        nativeAsset.Quantity = nativeAsset.Quantity + na.Value;                       
+                        nativeAsset.Quantity = nativeAsset.Quantity + na.Value;
                     }
                 }
             }
 
-             // remove / add assets from balance based on mint / burn token bundle
+            // remove / add assets from balance based on mint / burn token bundle
             if (mint is not null) {
                 var mintAssets = mint.Build();
                 foreach (var ma  in mintAssets) {
                     foreach (var na in ma.Value.Token) {
                         var nativeAsset = balance.Assets.FirstOrDefault(x =>
-                            x.PolicyId.SequenceEqual(ma.Key.ToStringHex()) && 
+                            x.PolicyId.SequenceEqual(ma.Key.ToStringHex()) &&
                             x.Name.Equals(na.Key.ToStringHex()));
                         if (nativeAsset is not null)
                         {
@@ -76,10 +76,10 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
                                 balance.Assets.Add(nativeAsset);
                             }
                         }
-                    }                
+                    }
                 }
-            }   
-            
+            }
+
             return balance;
         }
     }

--- a/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
@@ -9,17 +9,18 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
 {
     public static partial class TransactionOutputExtensions
     {
-        public static Balance AggregateAssets(this IEnumerable<TransactionOutput> transactionOutputs, ulong fee = 0)
+        public static Balance AggregateAssets(this IEnumerable<TransactionOutput> transactionOutputs, ulong feeBuffer = 0)
         {
             Balance balance = new Balance()
             {
+                Lovelaces = feeBuffer,
                 Assets = new List<Asset>()
             };
 
             foreach (var o in transactionOutputs)
             {
                 //aggregate lovelaces and optional fee
-                balance.Lovelaces = balance.Lovelaces + o.Value.Coin + fee;
+                balance.Lovelaces = balance.Lovelaces + o.Value.Coin;
 
                 //aggregate native assets
                 if(o.Value.MultiAsset is null) continue;

--- a/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
@@ -47,34 +47,35 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
                 }
             }
 
+            if (mint is null)
+                return balance;
+
             // remove / add assets from balance based on mint / burn token bundle
-            if (mint is not null) {
-                var mintAssets = mint.Build();
-                foreach (var ma  in mintAssets) {
-                    foreach (var na in ma.Value.Token) {
-                        var nativeAsset = balance.Assets.FirstOrDefault(x =>
-                            x.PolicyId.SequenceEqual(ma.Key.ToStringHex()) &&
-                            x.Name.Equals(na.Key.ToStringHex()));
-                        if (nativeAsset is not null)
-                        {
-                            // remove native asset value from balance, if burning tokens, this will add to the balance
-                            nativeAsset.Quantity = nativeAsset.Quantity - na.Value;
-                            if (nativeAsset.Quantity <= 0) {
-                                balance.Assets.Remove(nativeAsset);
-                            }
+            var mintAssets = mint.Build();
+            foreach (var ma  in mintAssets) {
+                foreach (var na in ma.Value.Token) {
+                    var nativeAsset = balance.Assets.FirstOrDefault(x =>
+                        x.PolicyId.SequenceEqual(ma.Key.ToStringHex()) &&
+                        x.Name.Equals(na.Key.ToStringHex()));
+                    if (nativeAsset is not null)
+                    {
+                        // remove native asset value from balance, if burning tokens, this will add to the balance
+                        nativeAsset.Quantity = nativeAsset.Quantity - na.Value;
+                        if (nativeAsset.Quantity <= 0) {
+                            balance.Assets.Remove(nativeAsset);
                         }
-                        else {
-                            long quantity = -na.Value; // Only add a required balance asset if an NFT is being burned
-                            if (quantity > 0)
+                    }
+                    else {
+                        long quantity = -na.Value; // Only add a required balance asset if an NFT is being burned
+                        if (quantity > 0)
+                        {
+                            nativeAsset = new Asset()
                             {
-                                nativeAsset = new Asset()
-                                {
-                                    PolicyId = ma.Key.ToStringHex(),
-                                    Name = na.Key.ToStringHex(),
-                                    Quantity = quantity
-                                };
-                                balance.Assets.Add(nativeAsset);
-                            }
+                                PolicyId = ma.Key.ToStringHex(),
+                                Name = na.Key.ToStringHex(),
+                                Quantity = quantity
+                            };
+                            balance.Assets.Add(nativeAsset);
                         }
                     }
                 }

--- a/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
+++ b/CardanoSharp.Wallet/CIPs/CIP2/Extensions/TransactionOutputExtensions.cs
@@ -9,7 +9,7 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
 {
     public static partial class TransactionOutputExtensions
     {
-        public static Balance AggregateAssets(this IEnumerable<TransactionOutput> transactionOutputs)
+        public static Balance AggregateAssets(this IEnumerable<TransactionOutput> transactionOutputs, ulong fee = 0)
         {
             Balance balance = new Balance()
             {
@@ -18,8 +18,8 @@ namespace CardanoSharp.Wallet.CIPs.CIP2.Extensions
 
             foreach (var o in transactionOutputs)
             {
-                //aggregate lovelaces
-                balance.Lovelaces = balance.Lovelaces + o.Value.Coin;
+                //aggregate lovelaces and optional fee
+                balance.Lovelaces = balance.Lovelaces + o.Value.Coin + fee;
 
                 //aggregate native assets
                 if(o.Value.MultiAsset is null) continue;

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.1</Version>
+    <Version>4.0.0</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Enums/OutputPurpose.cs
+++ b/CardanoSharp.Wallet/Enums/OutputPurpose.cs
@@ -5,6 +5,5 @@
         Spend,
         Change,
         Mint,
-        Burn,
     }
 }

--- a/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionOutputExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/Transactions/TransactionOutputExtensions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using CardanoSharp.Wallet.Models.Transactions;
+using CardanoSharp.Wallet.Models.Addresses;
 using PeterO.Cbor2;
 
 namespace CardanoSharp.Wallet.Extensions.Models.Transactions
@@ -109,11 +110,11 @@ namespace CardanoSharp.Wallet.Extensions.Models.Transactions
 
 			// Set a dummy address if this function is called with Address == null
 			if (output.Address == null)
-				output.Address = dummyAddress.ToBytes();
+				output.Address = new Address(dummyAddress).GetBytes();
 
 			byte[] serializedOutput = output.Serialize();
 			ulong outputLength = (ulong)serializedOutput.Length;
-			ulong minUTxO = coinsPerUtxOByte * (160 + outputLength);
+			ulong minUTxO = coinsPerUtxOByte * (160 + outputLength + 4); // Adding 4 as the transaction output for babbage has a datum_option and ref_script parameter that are 2+2 = 4 extra bytes that we have not added yet
 			if (minUTxO < adaOnlyMinUTxO)
 				minUTxO = adaOnlyMinUTxO;
 

--- a/CardanoSharp.Wallet/TransactionBuilding/TransactionBodyBuilder.cs
+++ b/CardanoSharp.Wallet/TransactionBuilding/TransactionBodyBuilder.cs
@@ -13,8 +13,8 @@ namespace CardanoSharp.Wallet.TransactionBuilding
     {
         ITransactionBodyBuilder AddInput(byte[] transactionId, uint transactionIndex);
         ITransactionBodyBuilder AddInput(string transactionId, uint transactionIndex);
-        ITransactionBodyBuilder AddOutput(byte[] address, ulong coin, OutputPurpose outputPurpose = OutputPurpose.Spend, ITokenBundleBuilder tokenBundleBuilder = null);
-        ITransactionBodyBuilder AddOutput(Address address, ulong coin, OutputPurpose outputPurpose = OutputPurpose.Spend, ITokenBundleBuilder tokenBundleBuilder = null);
+        ITransactionBodyBuilder AddOutput(byte[] address, ulong coin, ITokenBundleBuilder tokenBundleBuilder = null, OutputPurpose outputPurpose = OutputPurpose.Spend);
+        ITransactionBodyBuilder AddOutput(Address address, ulong coin, ITokenBundleBuilder tokenBundleBuilder = null, OutputPurpose outputPurpose = OutputPurpose.Spend);
         ITransactionBodyBuilder SetCertificate(ICertificateBuilder certificateBuilder);
         ITransactionBodyBuilder SetFee(ulong fee);
         ITransactionBodyBuilder SetTtl(uint ttl);
@@ -90,12 +90,12 @@ namespace CardanoSharp.Wallet.TransactionBuilding
             return this;
         }
 
-        public ITransactionBodyBuilder AddOutput(Address address, ulong coin, OutputPurpose outputPurpose = OutputPurpose.Spend, ITokenBundleBuilder tokenBundleBuilder = null)
+        public ITransactionBodyBuilder AddOutput(Address address, ulong coin, ITokenBundleBuilder tokenBundleBuilder = null, OutputPurpose outputPurpose = OutputPurpose.Spend)
         {
-            return AddOutput(address.GetBytes(), coin, outputPurpose, tokenBundleBuilder);
+            return AddOutput(address.GetBytes(), coin, tokenBundleBuilder, outputPurpose);
         }
 
-        public ITransactionBodyBuilder AddOutput(byte[] address, ulong coin, OutputPurpose outputPurpose = OutputPurpose.Spend, ITokenBundleBuilder tokenBundleBuilder = null)
+        public ITransactionBodyBuilder AddOutput(byte[] address, ulong coin, ITokenBundleBuilder tokenBundleBuilder = null,  OutputPurpose outputPurpose = OutputPurpose.Spend)
         {
             var outputValue = new TransactionOutputValue()
             {


### PR DESCRIPTION
This PR overhauls coin selection algorithm and change selection.

- Before we were only checking the ADA inputs after the balance was checked for inputs. But this could fail as change outputs with tokens could exist that we need to account for after selecting ada.
- As a result of the above, this new algorithm which follows similarly to the Nami wallet implementation with some improvements (https://github.com/berry-pool/nami/blob/b5e7280dd3204360160959dfa1d548eec97918a0/src/lib/coinSelection.js#L522).

The algorithm works as follows:
1. Perform the same logic for asset selection with bundles (but reverse values for mint and burn multiassets)
2. Immediately perform an ada input selection and change selection.
3. Ensure the exact input - output required change is greater than the minUTXO change input outputs.
4. If not perform another ada selection by adding the difference in input - output change from the require change. 
5. Loop step 3 and 4 until either the change is correct or until we run out of UTXOs or until we cannot create a balance greater than the ada amount. The Nami wallet uses an if statement here instead of a loop which can miss corner cases with high NFT counts and low ada amounts.


This PR also adds several parameters to improve the coin selection algorithms:
- changeAddress: This parameter automatically sets the output change address so we do not need to do this outside of the coin selection functions.
- mint: This optional token bundle builder is included to allow the coin selections to support both burning and minting. Using outputPurpose we were not able to support burning because we could never guarentee that a UTXO would include the burned token because Cardano outputs cannot have negative numbers.
- feeBuffer: This parameter adds a buffer for fees to ensure we have enough ada in our selected inputs to satisfy Cardano fees. 


In addition, the CIP2 tests have been updated and are working on tests. This is also working in live production tests =D