### PR TITLE
switched GetUtxo method to Hex AssetName

### DIFF
--- a/CardanoSharp.Wallet.Test/CIPs/CIP30Tests.cs
+++ b/CardanoSharp.Wallet.Test/CIPs/CIP30Tests.cs
@@ -125,7 +125,7 @@ public class CIP30Tests
 		Assert.NotNull(utxo.Balance.Assets);
 		Assert.Equal(1, utxo.Balance.Assets.Count);
 		Assert.Equal("635da8872ab583e67993c69e67f50f12cc34ef8e1e1d93da9a9fe0cd", utxo.Balance.Assets.First().PolicyId);
-		Assert.Equal("TMON", utxo.Balance.Assets.First().Name);
+		Assert.Equal("544d4f4e", utxo.Balance.Assets.First().Name);
 		Assert.Equal((long)6000, utxo.Balance.Assets.First().Quantity);
 	}
 

--- a/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
+++ b/CardanoSharp.Wallet/CardanoSharp.Wallet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.5</Version>
+    <Version>4.0.6</Version>
     <PackageProjectUrl>https://github.com/CardanoSharp/cardanosharp-wallet</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CardanoSharp/cardanosharp-wallet</RepositoryUrl>
   </PropertyGroup>

--- a/CardanoSharp.Wallet/Extensions/Models/UtxoExtensions.cs
+++ b/CardanoSharp.Wallet/Extensions/Models/UtxoExtensions.cs
@@ -77,7 +77,7 @@ namespace CardanoSharp.Wallet.Extensions.Models
 			{
 				utxo.Balance.Assets = tempOutput.Value.MultiAsset.SelectMany(
 					x => x.Value.Token.Select(
-						y => new Asset() { PolicyId = x.Key.ToStringHex(), Name = y.Key.GetString(), Quantity = y.Value }
+						y => new Asset() { PolicyId = x.Key.ToStringHex(), Name = y.Key.ToStringHex(), Quantity = y.Value }
 						)
 					).ToList();
 			}

--- a/CardanoSharp.Wallet/Extensions/StringExtension.cs
+++ b/CardanoSharp.Wallet/Extensions/StringExtension.cs
@@ -14,11 +14,6 @@ namespace CardanoSharp.Wallet.Extensions
 			return hex;
 		}
 
-		public static string GetString(this byte[] bytes)
-		{
-			return System.Text.Encoding.UTF8.GetString(bytes);
-		}
-
 		public static byte[] ToBytes(this string value)
 		{
 			return System.Text.Encoding.UTF8.GetBytes(value);


### PR DESCRIPTION
Currently uses utf8 encoded strings. This doesn't work for all asset names and isn't in line with the chain spec:

The Mary era of Cardano introduces the support for native assets. On the blockchain, native assets are uniquely identified by both their so-called policy id and asset name. Neither the policy id nor the asset name are intended to be human-readable data.
On the one hand, the policy id is a hash digest of either a monetary script or a Plutus script. **On the other hand, the asset name is an arbitrary bytestring of up to 32 bytes (which does not necessarily decode to a valid UTF-8 sequence).** In addition, it is possible for an asset to have an empty asset name, or, for assets to have identical asset names under different policies.
Because assets are manipulated in several user-facing features on desktop and via hardware applications, it is useful to come up with a short(er) and human-readable identifier for assets that user can recognize and refer to when talking about assets. We call such an identifier an asset fingerprint.
Specification